### PR TITLE
Improve swarm display and timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# swarm
+# Swarm Simulation
+
+This repository contains a simple Python program that simulates a swarm of red dots on a black background. The user can place a single flag by clicking the mouse, and the dots will attempt to move toward that flag. Only one red dot can occupy a pixel at any time.
+
+## Requirements
+
+- Python 3
+- [Pygame](https://www.pygame.org/)
+- [pyenv](https://github.com/pyenv/pyenv) with [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv)
+
+Dependencies install automatically via `run.sh`, but pyenv and pyenv-virtualenv
+must be installed and initialized in your shell. If you encounter an error about
+`pyenv activate` not being available, ensure you have run:
+
+```bash
+eval "$(pyenv init -)"
+eval "$(pyenv virtualenv-init -)"
+```
+
+## Running
+
+Execute the simulation using the provided helper script:
+
+```bash
+./run.sh
+```
+
+Click anywhere in the window to place the target flag for the swarm. The
+simulation updates about 10 times per second and displays a small flag
+instead of a green square.

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -e
+
+ENV_NAME="swarm-env"
+
+if ! command -v pyenv >/dev/null; then
+  echo "pyenv is required but not installed. Please install pyenv first." >&2
+  exit 1
+fi
+
+# Initialize pyenv and pyenv-virtualenv in this shell
+export PYENV_ROOT="$(pyenv root)"
+eval "$(pyenv init -)"
+if command -v pyenv-virtualenv-init >/dev/null; then
+  eval "$(pyenv virtualenv-init -)"
+else
+  echo "pyenv-virtualenv is required but not installed." >&2
+  exit 1
+fi
+
+# Create virtualenv if it does not exist
+if ! pyenv versions --bare | grep -qx "$ENV_NAME"; then
+  PYTHON_VERSION="$(pyenv global)"
+  pyenv virtualenv "$PYTHON_VERSION" "$ENV_NAME"
+fi
+
+pyenv activate "$ENV_NAME"
+
+# Install dependencies
+pip install --upgrade pip >/dev/null
+pip install pygame >/dev/null
+
+# Run the game
+python swarm.py

--- a/swarm.py
+++ b/swarm.py
@@ -1,0 +1,69 @@
+import pygame
+import sys
+import random
+
+WIDTH, HEIGHT = 640, 480
+NUM_DOTS = 50
+DOT_COLOR = (255, 0, 0)  # red
+BACKGROUND_COLOR = (0, 0, 0)  # black
+FLAG_COLOR = (0, 255, 0)  # green
+FLAG_POLE_COLOR = (200, 200, 200)
+DOT_SIZE = 2
+
+pygame.init()
+screen = pygame.display.set_mode((WIDTH, HEIGHT))
+clock = pygame.time.Clock()
+
+# Initialize dots at random positions
+dots = []
+occupied = set()
+while len(dots) < NUM_DOTS:
+    x = random.randint(0, WIDTH - 1)
+    y = random.randint(0, HEIGHT - 1)
+    if (x, y) not in occupied:
+        dots.append([x, y])
+        occupied.add((x, y))
+
+flag_pos = None
+
+running = True
+while running:
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            running = False
+        elif event.type == pygame.MOUSEBUTTONDOWN:
+            flag_pos = event.pos
+
+    # Update dots toward the flag
+    if flag_pos is not None:
+        new_occupied = set()
+        for i, (x, y) in enumerate(dots):
+            dx = 0 if flag_pos[0] == x else (1 if flag_pos[0] > x else -1)
+            dy = 0 if flag_pos[1] == y else (1 if flag_pos[1] > y else -1)
+            nx, ny = x + dx, y + dy
+            # Ensure only one dot per pixel
+            if (nx, ny) not in new_occupied and (0 <= nx < WIDTH) and (0 <= ny < HEIGHT):
+                dots[i] = [nx, ny]
+                new_occupied.add((nx, ny))
+            else:
+                new_occupied.add((x, y))
+        occupied = new_occupied
+
+    screen.fill(BACKGROUND_COLOR)
+    if flag_pos is not None:
+        fx, fy = flag_pos
+        pole_top = (fx, max(0, fy - 10))
+        pygame.draw.line(screen, FLAG_POLE_COLOR, flag_pos, pole_top)
+        flag_points = [
+            pole_top,
+            (pole_top[0] + 6, pole_top[1] + 3),
+            (pole_top[0], pole_top[1] + 6),
+        ]
+        pygame.draw.polygon(screen, FLAG_COLOR, flag_points)
+    for x, y in dots:
+        pygame.draw.rect(screen, DOT_COLOR, (x, y, DOT_SIZE, DOT_SIZE))
+    pygame.display.flip()
+    clock.tick(10)
+
+pygame.quit()
+sys.exit()


### PR DESCRIPTION
## Summary
- redraw the flag with a pole and triangle
- draw the flag before the swarm dots so dots remain visible
- slow the simulation to 10 updates per second
- document the new visuals and timing in README

## Testing
- `python3 -m py_compile swarm.py && bash -n run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68443f691268832ebf600f64ff37963b