### PR TITLE
Fix flag highlight and allow backspace removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Execute the simulation using the provided helper script:
 Use the `1` and `2` keys to choose which red flag is active. The icons for the
 two flags are shown at the bottom of the window. The active flag is highlighted
 with a rectangle. Click anywhere to place the currently active flag. Press the
-`Delete` key to remove it. The simulation updates about 10 times per second and
-displays a small flag instead of a green square.
+`Delete` key (or `Backspace` on macOS keyboards) to remove it. The simulation
+updates about 10 times per second and displays a small flag instead of a green
+square.
 
 ## Gameplay
 

--- a/swarm.py
+++ b/swarm.py
@@ -199,7 +199,7 @@ def draw_flag_icon(idx, active=False):
     base_y = HEIGHT - 5
     draw_flag((base_x, base_y), FLAG_COLOR_RED, idx + 1)
     if active:
-        rect = pygame.Rect(base_x - FLAG_SIZE - 4, base_y - 16, FLAG_SIZE + 12, FLAG_SIZE + 20)
+        rect = pygame.Rect(base_x - 4, base_y - 16, FLAG_SIZE + 12, FLAG_SIZE + 20)
         pygame.draw.rect(screen, (255, 255, 0), rect, 1)
 
 
@@ -234,7 +234,7 @@ while running:
                 active_flag_idx = 0
             elif event.key == pygame.K_2:
                 active_flag_idx = 1
-            elif event.key == pygame.K_DELETE:
+            elif event.key in (pygame.K_DELETE, pygame.K_BACKSPACE):
                 flags_red[active_flag_idx] = None
         elif event.type == pygame.MOUSEBUTTONDOWN:
             flags_red[active_flag_idx] = event.pos


### PR DESCRIPTION
## Summary
- highlight active flag icons correctly
- allow removing a flag with Backspace
- document Backspace support in README

## Testing
- `bash run.sh` *(fails: pyenv-virtualenv is required but not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68453b30e208832ea010a4a54537fc6d