### PR TITLE
Add stop flag type

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ Execute the simulation using the provided helper script:
 ./run.sh
 ```
 
-Use the `1`, `2` and `3` keys to choose which red flag is active. The icons for the
-three flags are shown at the bottom of the window. The active flag is highlighted
+Use the `1`, `2`, `3` and `4` keys to choose which red flag is active. The icons for the
+four flags are shown at the bottom of the window. The active flag is highlighted
 with a rectangle. Flags 1 and 2 behave normally while flag 3 orders ants to move
-quickly (speed ×1.5) and disables their attacks. Click anywhere to place the currently
+quickly (speed ×1.5) and disables their attacks. Flag 4 tells ants to stay put while still
+allowing them to attack. Click anywhere to place the currently
 active flag. Press the `Delete` key (or `Backspace` on macOS keyboards) to remove it. The simulation
 updates about 10 times per second and displays a small flag instead of a green
 square.

--- a/swarm.py
+++ b/swarm.py
@@ -27,6 +27,7 @@ ANT_COLOR_BLUE_ENGAGED = lighten(ANT_COLOR_BLUE)
 # Flag types
 FLAG_TYPE_NORMAL = "normal"
 FLAG_TYPE_FAST = "fast"
+FLAG_TYPE_STOP = "stop"
 
 BACKGROUND_COLOR = (0, 0, 0)
 FLAG_COLOR_RED = (255, 100, 100)  # light red
@@ -152,7 +153,8 @@ def propose_moves(ants, attackers, flags, all_ants):
         speed_mult = 1.5 if flag["type"] == FLAG_TYPE_FAST else 1.0
         speed = (0.3 if i in attackers else 1.0) * speed_mult
 
-        vx, vy = compute_move_vector(x, y, flag["pos"], all_ants)
+        target_pos = (x, y) if flag["type"] == FLAG_TYPE_STOP else flag["pos"]
+        vx, vy = compute_move_vector(x, y, target_pos, all_ants)
         nx = max(0, min(WIDTH - 1, x + vx * speed))
         ny = max(0, min(HEIGHT - 1, y + vy * speed))
         proposed.append((nx, ny))
@@ -200,6 +202,15 @@ def draw_flag(flag_pos, color, number=None, flag_type=FLAG_TYPE_NORMAL):
         bottom2 = (pole_top[0] + FLAG_SIZE // 2, pole_top[1] + FLAG_SIZE)
         pygame.draw.polygon(screen, color, [left1, right1, bottom1])
         pygame.draw.polygon(screen, color, [left2, right2, bottom2])
+    elif flag_type == FLAG_TYPE_STOP:
+        bar_height = 3
+        gap = 2
+        rect1 = pygame.Rect(pole_top[0], pole_top[1], FLAG_SIZE, bar_height)
+        rect2 = pygame.Rect(
+            pole_top[0], pole_top[1] + bar_height + gap, FLAG_SIZE, bar_height
+        )
+        pygame.draw.rect(screen, color, rect1)
+        pygame.draw.rect(screen, color, rect2)
     else:
         flag_points = [
             pole_top,
@@ -244,6 +255,7 @@ flags_red = [
     {"pos": None, "type": FLAG_TYPE_NORMAL},
     {"pos": None, "type": FLAG_TYPE_NORMAL},
     {"pos": None, "type": FLAG_TYPE_FAST},
+    {"pos": None, "type": FLAG_TYPE_STOP},
 ]
 active_flag_idx = 0
 flag_pos_blue = (random.uniform(0, WIDTH), random.uniform(0, HEIGHT))
@@ -261,6 +273,8 @@ while running:
                 active_flag_idx = 1
             elif event.key == pygame.K_3:
                 active_flag_idx = 2
+            elif event.key == pygame.K_4:
+                active_flag_idx = 3
             elif event.key in (pygame.K_DELETE, pygame.K_BACKSPACE):
                 flags_red[active_flag_idx]["pos"] = None
         elif event.type == pygame.MOUSEBUTTONDOWN:


### PR DESCRIPTION
## Summary
- add new `stop` flag type
- allow selecting the new flag with the `4` key
- draw a pause-like icon for stop flags
- update documentation with new key and behaviour

## Testing
- `python -m py_compile swarm.py`
- `python swarm.py` *(fails: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_6845676732d0832ea6ab365e14e01e2a