### PR TITLE
Add archer-specific flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Execute the simulation using the provided helper script:
 
 Use the `1`, `2`, `3` and `4` keys to choose which red flag is active. The icons for the
 four flags are shown at the bottom of the window. The active flag is highlighted
-with a rectangle. Flags 1 and 2 behave normally while flag 3 orders ants to move
-quickly (speed ×1.5) and disables their attacks. Flag 4 tells ants to stay put while still
+with a rectangle. Flag 1 is a standard footman flag, flag 2 commands only archers,
+flag 3 orders units to move quickly (speed ×1.5) and disables their attacks. Flag 4 tells ants to stay put while still
 allowing them to attack. Click anywhere to place the currently
 active flag. Press the `Delete` key (or `Backspace` on macOS keyboards) to remove it. The simulation
 updates about 10 times per second and displays a small flag instead of a green


### PR DESCRIPTION
## Summary
- add `FLAG_TYPE_ARCHER`
- assign flag 2 to archers only
- filter flags for footmen vs archers
- render a cross mark on archer flags
- document the new flag behaviour in README

## Testing
- `python -m py_compile swarm.py`

------
https://chatgpt.com/codex/tasks/task_e_6845a1bdfb84832e8834b049cf50d4f5