### PR TITLE
Fix path starting point and backspace behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ archers in group `2`. Flag 1 controls only group `1`, flag 2 controls only group
 `2`, flag 3 orders units to move quickly (speed ×1.5) and disables their attacks,
 and flag 4 tells ants to stay put while still allowing them to attack. Click
 anywhere to append a new command to the queue. Commands are executed in the
-order they were added. Press the `Delete` key (or `Backspace` on macOS
-keyboards) to remove the most recently queued flag. A dashed line shows the
-planned path from the controlled group to each flag in the queue. The simulation
+order they were added. Press the `Delete` key to remove the most recently
+queued flag. Press `Backspace` to clear all queued flags. A dashed line shows the
+planned path from the targeted control group to each flag in the queue. The simulation
 updates about 10 times per second and displays a small flag instead of a green
 square.
 Each control group also shows a small banner at its center of mass with the

--- a/swarm.py
+++ b/swarm.py
@@ -424,9 +424,11 @@ while running:
                 active_flag_idx = 2
             elif event.key == pygame.K_4:
                 active_flag_idx = 3
-            elif event.key in (pygame.K_DELETE, pygame.K_BACKSPACE):
+            elif event.key == pygame.K_DELETE:
                 if flag_queue:
                     flag_queue.pop()
+            elif event.key == pygame.K_BACKSPACE:
+                flag_queue.clear()
         elif event.type == pygame.MOUSEBUTTONDOWN:
             template = flag_templates[active_flag_idx]
             flag_queue.append({"pos": event.pos, "type": template["type"], "group": template["group"]})
@@ -563,8 +565,16 @@ while running:
     draw_group_banner(ants_footmen, ANT_COLOR_RED, GROUP_FOOTMEN)
     draw_group_banner(ants_archers, ANT_COLOR_ARCHER, GROUP_ARCHERS)
 
-    if center_all and flag_queue:
-        draw_flag_path(center_all, flag_queue)
+    if flag_queue:
+        first_group = flag_queue[0].get("group")
+        if first_group == GROUP_FOOTMEN:
+            start_center = compute_centroid(ants_footmen)
+        elif first_group == GROUP_ARCHERS:
+            start_center = compute_centroid(ants_archers)
+        else:
+            start_center = center_all
+        if start_center:
+            draw_flag_path(start_center, flag_queue)
 
     for idx, flag in enumerate(flag_queue, start=1):
         draw_flag(flag["pos"], FLAG_COLOR_RED, idx, flag["type"])


### PR DESCRIPTION
## Summary
- draw the flag path starting from the group targeted by the first flag
- use backspace to clear the entire path
- document the updated controls in the README

## Testing
- `python -m py_compile swarm.py`

------
https://chatgpt.com/codex/tasks/task_e_6846ad5409bc832eb283e33322e68f9c