### PR TITLE
Implement per-group command queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,11 @@ Groups are numbered from `1` to `9`; by default footmen are in group `1` and
 archers in group `2`. Flag 1 controls only group `1`, flag 2 controls only group
 `2`, flag 3 orders units to move quickly (speed ×1.5) and disables their attacks,
 and flag 4 tells ants to stay put while still allowing them to attack. Click
-anywhere to append a new command to the queue. Commands are executed in the
-order they were added. Press the `Delete` key to remove the most recently
-queued flag. Press `Backspace` to clear all queued flags. A dashed line shows the
-planned path from the targeted control group to each flag in the queue. The simulation
+anywhere to append a new command to the selected group's queue. Each control group
+maintains its own list of commands executed in the order they were added. Press the
+`Delete` key to remove the most recently queued flag for the active group. Press
+`Backspace` to clear that group's queue. A dashed line shows the planned path from the
+targeted control group to each flag in its queue. The simulation
 updates about 10 times per second and displays a small flag instead of a green
 square.
 Each control group also shows a small banner at its center of mass with the


### PR DESCRIPTION
## Summary
- manage a queue of orders separately for each control group
- track which control group is active and apply flag commands only to that group
- highlight the active group's banner on the battlefield
- update README to document group-specific queues

## Testing
- `python -m py_compile swarm.py`
- `python swarm.py` *(fails: ModuleNotFoundError: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_6846b81caffc832ebc9308371e18a659