### PR TITLE
Show queued paths for every control group

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ and flag 4 tells ants to stay put while still allowing them to attack. Click
 anywhere to append a new command to the selected group's queue. Each control group
 maintains its own list of commands executed in the order they were added. Press the
 `Delete` key to remove the most recently queued flag for the active group. Press
-`Backspace` to clear that group's queue. A dashed line shows the planned path from the
-targeted control group to each flag in its queue. The simulation
+`Backspace` to clear that group's queue. A dashed line shows the planned path from
+each control group to the flags in its queue so you can see orders for all groups
+at a glance. The simulation
 updates about 10 times per second and displays a small flag instead of a green
 square.
 Each control group also shows a small banner at its center of mass with the

--- a/swarm.py
+++ b/swarm.py
@@ -566,14 +566,15 @@ while running:
         ants_archers, ANT_COLOR_ARCHER, GROUP_ARCHERS, active_group == GROUP_ARCHERS
     )
 
-    active_queue = flag_queues[active_group]
-    if active_queue:
-        if active_group == GROUP_FOOTMEN:
-            start_center = compute_centroid(ants_footmen)
-        else:
-            start_center = compute_centroid(ants_archers)
-        if start_center:
-            draw_flag_path(start_center, active_queue)
+    for group_id, ants in [
+        (GROUP_FOOTMEN, ants_footmen),
+        (GROUP_ARCHERS, ants_archers),
+    ]:
+        queue = flag_queues[group_id]
+        if queue:
+            start_center = compute_centroid(ants)
+            if start_center:
+                draw_flag_path(start_center, queue)
 
     for idx, flag in enumerate(flag_queues[GROUP_FOOTMEN], start=1):
         draw_flag(flag["pos"], FLAG_COLOR_RED, idx, flag["type"])


### PR DESCRIPTION
## Summary
- draw command paths for all control groups
- document that each group shows its queued path

## Testing
- `python -m py_compile swarm.py`

------
https://chatgpt.com/codex/tasks/task_e_6846ba2ecf00832e9ea491d113acca29