### PR TITLE
Support removing queued flags via click

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ and flag 4 tells ants to stay put while still allowing them to attack. Click
 anywhere to append a new command to the selected group's queue. Each control group
 maintains its own list of commands executed in the order they were added. Press the
 `Delete` key to remove the most recently queued flag for the active group. Press
-`Backspace` to clear that group's queue. A dashed line shows the planned path from
+`Backspace` to clear that group's queue. Clicking a flag along its path removes
+only that flag from the queue. A dashed line shows the planned path from
 each control group to the flags in its queue so you can see orders for all groups
 at a glance. The simulation
 updates about 10 times per second and displays a small flag instead of a green

--- a/swarm.py
+++ b/swarm.py
@@ -437,8 +437,19 @@ while running:
             elif event.key == pygame.K_BACKSPACE:
                 flag_queues[active_group].clear()
         elif event.type == pygame.MOUSEBUTTONDOWN:
-            template = flag_templates[active_flag_idx]
-            flag_queues[active_group].append({"pos": event.pos, "type": template["type"]})
+            removed = False
+            for gid, queue in flag_queues.items():
+                for i, flag in enumerate(queue):
+                    fx, fy = flag["pos"]
+                    if math.hypot(fx - event.pos[0], fy - event.pos[1]) <= FLAG_SIZE:
+                        queue.pop(i)
+                        removed = True
+                        break
+                if removed:
+                    break
+            if not removed:
+                template = flag_templates[active_flag_idx]
+                flag_queues[active_group].append({"pos": event.pos, "type": template["type"]})
 
     # move the computer-controlled flags alternately
     now = time.time()


### PR DESCRIPTION
## Summary
- enable clicking on flags in the command path to remove them
- document how clicking a flag removes it from the queue

## Testing
- `python -m py_compile swarm.py`

------
https://chatgpt.com/codex/tasks/task_e_6846be5b26b4832e838844d053624ff9