### PR TITLE
Implement shift-click fast flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Groups are numbered from `1` to `9`; by default footmen are in group `1` and
 archers in group `2`. Flag 1 controls only group `1`, flag 2 controls only group
 `2`, flag 3 orders units to move quickly (speed ×1.5) and disables their attacks,
 and flag 4 tells ants to stay put while still allowing them to attack. Click
-anywhere to append a new command to the selected group's queue. Each control group
+anywhere to append a new command to the selected group's queue. Holding `Shift`
+while clicking places a fast-move flag regardless of the current selection. Each control group
 maintains its own list of commands executed in the order they were added. Press the
 `Delete` key to remove the most recently queued flag for the active group. Press
 `Backspace` to clear that group's queue. Clicking a flag along its path removes

--- a/swarm.py
+++ b/swarm.py
@@ -448,8 +448,11 @@ while running:
                 if removed:
                     break
             if not removed:
-                template = flag_templates[active_flag_idx]
-                flag_queues[active_group].append({"pos": event.pos, "type": template["type"]})
+                if pygame.key.get_mods() & pygame.KMOD_SHIFT:
+                    flag_type = FLAG_TYPE_FAST
+                else:
+                    flag_type = flag_templates[active_flag_idx]["type"]
+                flag_queues[active_group].append({"pos": event.pos, "type": flag_type})
 
     # move the computer-controlled flags alternately
     now = time.time()


### PR DESCRIPTION
## Summary
- allow shift-click to add a fast-move flag
- document shift-click behavior in README

## Testing
- `python -m py_compile swarm.py`
- `shellcheck run.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d307e58c832eb9fc976a5e9a8e8d