### PR TITLE
Implement OrderQueue stage

### DIFF
--- a/order_queue.py
+++ b/order_queue.py
@@ -1,0 +1,50 @@
+from stage import Stage
+from flag import Flag
+
+class OrderQueue(Stage):
+    """Stage subclass managing an ordered list of Flag objects."""
+
+    def __init__(self):
+        super().__init__()
+        self._queue = []
+
+    # ------------------------------------------------------------------
+    # Basic list operations
+    # ------------------------------------------------------------------
+    def add_flag(self, flag):
+        """Add ``flag`` to the end of the queue and as a child stage."""
+        if not isinstance(flag, Flag):
+            raise TypeError("flag must be a Flag instance")
+        self._queue.append(flag)
+        self.add_stage(flag)
+
+    def pop(self, index=-1):
+        """Remove and return a flag from the queue."""
+        if not self._queue:
+            return None
+        flag = self._queue.pop(index)
+        self.remove_stage(flag)
+        return flag
+
+    def remove(self, flag):
+        """Remove ``flag`` from the queue."""
+        self._queue.remove(flag)
+        self.remove_stage(flag)
+
+    def clear(self):
+        """Remove all flags from the queue."""
+        for flag in list(self._queue):
+            self.remove_stage(flag)
+        self._queue.clear()
+
+    # ------------------------------------------------------------------
+    # Container protocol helpers
+    # ------------------------------------------------------------------
+    def __len__(self):
+        return len(self._queue)
+
+    def __getitem__(self, item):
+        return self._queue[item]
+
+    def __iter__(self):
+        return iter(self._queue)

--- a/swarm.py
+++ b/swarm.py
@@ -6,6 +6,8 @@ import random
 import math
 import time
 
+from order_queue import OrderQueue
+
 from flag import (
     Flag,
     NormalFlag,
@@ -79,8 +81,8 @@ flag_templates = [
 
 # Queue of player-issued flags for each control group
 flag_queues = {
-    GROUP_FOOTMEN: [],
-    GROUP_ARCHERS: [],
+    GROUP_FOOTMEN: OrderQueue(),
+    GROUP_ARCHERS: OrderQueue(),
 }
 
 # Currently selected control group
@@ -388,7 +390,7 @@ while running:
                     flag_cls = flag_templates[active_flag_idx]["cls"]
                 new_flag = flag_cls(event.pos, FLAG_COLOR_RED)
                 new_flag.show()
-                flag_queues[active_group].append(new_flag)
+                flag_queues[active_group].add_flag(new_flag)
 
     # move the computer-controlled flags alternately
     now = time.time()


### PR DESCRIPTION
## Summary
- introduce new `OrderQueue` stage to manage flag lists
- use `OrderQueue` for control group queues in `swarm.py`
- update event handling to add/remove flags through `OrderQueue`

## Testing
- `python -m py_compile swarm.py flag.py stage.py order_queue.py`
- `python swarm.py` *(fails: ModuleNotFoundError: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_6846f37afe08832e99271b3e85c33b42