### PR TITLE
Add basic event handling and flag removal

### DIFF
--- a/flag.py
+++ b/flag.py
@@ -1,4 +1,5 @@
 import pygame
+import math
 from stage import Stage
 
 FLAG_SIZE = 12
@@ -41,6 +42,19 @@ class Flag(Stage):
         if self.pos is None:
             return
         self._draw_flag_at(screen, self.pos, self.number)
+
+    def _handle_event(self, event):
+        if event.type == pygame.MOUSEBUTTONDOWN and self.pos is not None:
+            if math.hypot(self.pos[0] - event.pos[0], self.pos[1] - event.pos[1]) <= FLAG_SIZE:
+                parent = getattr(self, "_parent", None)
+                if parent is not None:
+                    remove = getattr(parent, "remove", None)
+                    if callable(remove):
+                        remove(self)
+                    else:
+                        parent.remove_stage(self)
+                return True
+        return False
 
     def draw_icon(self, screen, idx, height, active=False):
         """Draw a small icon representation of this flag."""

--- a/order_queue.py
+++ b/order_queue.py
@@ -18,6 +18,13 @@ class OrderQueue(Stage):
         self._queue.append(flag)
         self.add_stage(flag)
 
+    def add_flag_at(self, pos, flag_cls=Flag):
+        """Create a new flag instance at ``pos`` and append it."""
+        flag = flag_cls(pos)
+        flag.show()
+        self.add_flag(flag)
+        return flag
+
     def pop(self, index=-1):
         """Remove and return a flag from the queue."""
         if not self._queue:

--- a/stage.py
+++ b/stage.py
@@ -4,6 +4,7 @@ class Stage:
     def __init__(self):
         self._visible = False
         self._children = []
+        self._parent = None
 
     # ------------------------------------------------------------------
     # Tree management
@@ -13,10 +14,12 @@ class Stage:
         if not isinstance(child, Stage):
             raise TypeError("child must be a Stage instance")
         self._children.append(child)
+        child._parent = self
 
     def remove_stage(self, child):
         """Detach a child stage from this stage."""
         self._children.remove(child)
+        child._parent = None
 
     # ------------------------------------------------------------------
     # Visibility control
@@ -39,6 +42,21 @@ class Stage:
             self._draw(screen)
             for child in self._children:
                 child.draw(screen)
+
+    def handleEvent(self, event):
+        """Process an event, returning True if it was consumed."""
+        if not self._visible:
+            return False
+        if self._handle_event(event):
+            return True
+        for child in list(self._children):
+            if child.handleEvent(event):
+                return True
+        return False
+
+    def _handle_event(self, event):
+        """Subclasses override to handle events."""
+        return False
 
     def _draw(self, screen):
         """Subclasses must implement actual drawing logic."""

--- a/swarm.py
+++ b/swarm.py
@@ -373,24 +373,17 @@ while running:
             elif event.key == pygame.K_BACKSPACE:
                 flag_queues[active_group].clear()
         elif event.type == pygame.MOUSEBUTTONDOWN:
-            removed = False
-            for gid, queue in flag_queues.items():
-                for i, flag in enumerate(queue):
-                    fx, fy = flag.pos
-                    if math.hypot(fx - event.pos[0], fy - event.pos[1]) <= FLAG_SIZE:
-                        queue.pop(i)
-                        removed = True
-                        break
-                if removed:
+            handled = False
+            for queue in flag_queues.values():
+                if queue.handleEvent(event):
+                    handled = True
                     break
-            if not removed:
+            if not handled:
                 if pygame.key.get_mods() & pygame.KMOD_SHIFT:
                     flag_cls = FastFlag
                 else:
                     flag_cls = flag_templates[active_flag_idx]["cls"]
-                new_flag = flag_cls(event.pos, FLAG_COLOR_RED)
-                new_flag.show()
-                flag_queues[active_group].add_flag(new_flag)
+                flag_queues[active_group].add_flag_at(event.pos, flag_cls)
 
     # move the computer-controlled flags alternately
     now = time.time()


### PR DESCRIPTION
## Summary
- propagate input events through Stage hierarchy
- allow flags to remove themselves when clicked
- support creating flags via `OrderQueue.add_flag_at`
- update game loop to use new event handling API

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6846f6600410832e975d73eed5fde2f4