### PR TITLE
Fix OrderQueue drawing

### DIFF
--- a/order_queue.py
+++ b/order_queue.py
@@ -55,3 +55,11 @@ class OrderQueue(Stage):
 
     def __iter__(self):
         return iter(self._queue)
+
+    # ------------------------------------------------------------------
+    # Drawing
+    # ------------------------------------------------------------------
+    def _draw(self, screen):
+        """Draw all flags in the queue."""
+        for flag in self._queue:
+            flag.draw(screen)


### PR DESCRIPTION
## Summary
- implement `_draw` in `OrderQueue` to render queued flags

## Testing
- `python main.py` *(fails: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_684700f6a194832e8d030907fa67d416