### PR TITLE
Fix flag position handling in Swarm

### DIFF
--- a/swarm.py
+++ b/swarm.py
@@ -257,7 +257,7 @@ class Swarm(Stage):
         self.ants = [list(p) for p in self._resolve_positions(self.ants, proposed)]
 
         center = self.compute_centroid()
-        if flag and center is not None:
+        if flag and flag.pos is not None and center is not None:
             if math.hypot(center[0] - flag.pos[0], center[1] - flag.pos[1]) < 40:
                 self.queue.pop(0)
 


### PR DESCRIPTION
## Summary
- guard against None flag positions before using them in Swarm._tick

## Testing
- `python main.py` *(fails: ModuleNotFoundError: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_6847270c8208832e8db4820fc37047ba