### PR TITLE
Fix Stage draw fallback

### DIFF
--- a/stage.py
+++ b/stage.py
@@ -59,8 +59,8 @@ class Stage:
         return False
 
     def _draw(self, screen):
-        """Subclasses must implement actual drawing logic."""
-        raise NotImplementedError
+        """Draw this stage element. Subclasses may override."""
+        pass
 
     # ------------------------------------------------------------------
     # Simulation


### PR DESCRIPTION
## Summary
- provide a default implementation of `Stage._draw`

## Testing
- `python -m py_compile stage.py ai_player.py order_queue.py flag.py swarm.py main.py`
- `./run.sh` *(fails: pyenv-virtualenv is required but not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684728f1a69c832e927a297ddc1eb638