### PR TITLE
Adjust AI move timing

### DIFF
--- a/ai_player.py
+++ b/ai_player.py
@@ -3,6 +3,9 @@ from swarm import Swarm
 from flag import NormalFlag, ArcherFlag
 import random
 
+# Simulation runs at 20 ticks per second (see main.py)
+TICKS_PER_SECOND = 20.0
+
 
 class AIPlayer(Stage):
     """Simple AI controller for the blue team."""
@@ -48,12 +51,14 @@ class AIPlayer(Stage):
         self.swarm_footmen.queue.add_flag(self.footmen_flag)
         self.swarm_archers.queue.add_flag(self.archer_flag)
 
-        self._time_since_move = 0.0
-        self._next_move_delay = random.uniform(5, 20)
+        self._time_since_move = 0.0  # seconds since last flag move
+        self._next_move_delay = random.uniform(5, 15)  # seconds
         self._next_flag_idx = 1
 
     def _tick(self, dt):
-        self._time_since_move += dt
+        # Convert the tick-based ``dt`` to seconds
+        dt_seconds = dt / TICKS_PER_SECOND
+        self._time_since_move += dt_seconds
         if self._time_since_move >= self._next_move_delay:
             pos = (
                 random.uniform(0, self.width),
@@ -65,5 +70,5 @@ class AIPlayer(Stage):
                 self.archer_flag.pos = pos
             self._next_flag_idx = 1 - self._next_flag_idx
             self._time_since_move = 0.0
-            self._next_move_delay = random.uniform(5, 20)
+            self._next_move_delay = random.uniform(5, 15)
 


### PR DESCRIPTION
## Summary
- slow down AI flag moves to every 5-15 seconds
- convert tick increments to seconds via a ticks-per-second constant

## Testing
- `python -m py_compile ai_player.py stage.py swarm.py main.py flag.py order_queue.py`

------
https://chatgpt.com/codex/tasks/task_e_68472aa48ebc832ea15dd6389f2e986c