### PR TITLE
Remove redundant child drawing in GameField

### DIFF
--- a/game_field.py
+++ b/game_field.py
@@ -124,10 +124,7 @@ class GameField(Stage):
     # ------------------------------------------------------------------
     # Drawing
     # ------------------------------------------------------------------
-    def draw(self, screen):
-        if not self._visible:
-            return
-
+    def _draw(self, screen):
         # Background and state updates
         screen.fill(self.BACKGROUND_COLOR)
         self.swarm_footmen.active = self.active_group == self.GROUP_FOOTMEN
@@ -136,10 +133,6 @@ class GameField(Stage):
         self.swarm_archers.engaged = set()
         self.ai_player.swarm_archers.engaged = set()
         self.ai_player.swarm_footmen.engaged = set()
-
-        # Draw swarms and AI
-        for child in self._children:
-            child.draw(screen)
 
         # Flag icons
         for idx, template in enumerate(self.flag_templates):


### PR DESCRIPTION
## Summary
- implement `_draw` in `GameField` so the parent `Stage` handles drawing children
- rely on automatic drawing from `Stage`

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6847b48b6aa0832eb6bb78f4530702ea