### PR TITLE
Show swarm size under banners

### DIFF
--- a/game_field.py
+++ b/game_field.py
@@ -140,19 +140,7 @@ class GameField(Stage):
             temp.show()
             temp.draw_icon(screen, idx, self.height, idx == self.active_flag_idx)
 
-        # Ant counts
-        count_text = self.font.render(
-            (
-                f"Footmen: {len(self.swarm_footmen.ants)}  "
-                f"Archers: {len(self.swarm_archers.ants)}  "
-                f"Blue Footmen: {len(self.ai_player.swarm_footmen.ants)}  "
-                f"Blue Archers: {len(self.ai_player.swarm_archers.ants)}"
-            ),
-            True,
-            (255, 255, 255),
-        )
-        text_rect = count_text.get_rect(topright=(self.width - 5, 5))
-        screen.blit(count_text, text_rect)
+
 
     # ------------------------------------------------------------------
     # Simulation - tick is inherited and propagates to children

--- a/swarm.py
+++ b/swarm.py
@@ -70,6 +70,12 @@ def draw_group_banner(screen, ants, color, number, active=False):
     text_rect = text.get_rect(center=center)
     screen.blit(text, text_rect)
 
+    # Display the size of the swarm just below the banner
+    count_font = pygame.font.Font(None, 14)
+    count_text = count_font.render(str(len(ants)), True, (255, 255, 255))
+    count_rect = count_text.get_rect(midtop=(center[0], rect.bottom + 2))
+    screen.blit(count_text, count_rect)
+
 
 def draw_dashed_line(screen, start_pos, end_pos, color=(200, 200, 200), dash_length=5):
     """Draw a dashed line between ``start_pos`` and ``end_pos``."""


### PR DESCRIPTION
## Summary
- display unit count below each group banner in `Swarm`
- remove global ant count overlay from `GameField`

## Testing
- `PYTHONPATH=$PWD SDL_VIDEODRIVER=dummy pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68485565c2e8832e83dcaf0ceed05893