### PR TITLE
Fix highlighting for attacking units

### DIFF
--- a/game_field.py
+++ b/game_field.py
@@ -136,10 +136,6 @@ class GameField(Stage):
         screen.fill(self.BACKGROUND_COLOR)
         self.swarm_footmen.active = self.active_group == self.GROUP_FOOTMEN
         self.swarm_archers.active = self.active_group == self.GROUP_ARCHERS
-        self.swarm_footmen.engaged = set()
-        self.swarm_archers.engaged = set()
-        self.ai_player.swarm_archers.engaged = set()
-        self.ai_player.swarm_footmen.engaged = set()
 
         # Flag icons
         for idx, template in enumerate(self.flag_templates):
@@ -159,6 +155,10 @@ class GameField(Stage):
         self._tick(dt)
 
     def _tick(self, dt):
+        self.swarm_footmen.engaged = set()
+        self.swarm_archers.engaged = set()
+        self.ai_player.swarm_archers.engaged = set()
+        self.ai_player.swarm_footmen.engaged = set()
         self._resolve_combat()
 
     # ------------------------------------------------------------------

--- a/tests/test_gamefield_flags.py
+++ b/tests/test_gamefield_flags.py
@@ -1,5 +1,8 @@
 import os
+import sys
 import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 pygame = pytest.importorskip('pygame')
 


### PR DESCRIPTION
## Summary
- clear engagement status at the start of each tick, not during drawing
- ensure tests can import modules correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684858e1c9fc832eb735b8f14fb1ba40