### PR TITLE
Fix last command removal

### DIFF
--- a/swarm.py
+++ b/swarm.py
@@ -287,5 +287,6 @@ class Swarm(Stage):
         center = self.compute_centroid()
         if flag and flag.pos is not None and center is not None:
             if math.hypot(center[0] - flag.pos[0], center[1] - flag.pos[1]) < 40:
-                self.queue.pop(0)
+                if len(self.queue) > 1:
+                    self.queue.pop(0)
 

--- a/tests/test_swarm_last_flag.py
+++ b/tests/test_swarm_last_flag.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from swarm import Swarm
+from flag import NormalFlag
+
+
+def create_swarm():
+    swarm = Swarm((255, 0, 0), group_id=1, flag_color=(255, 100, 100), width=100, height=100)
+    swarm.ants.append([50, 50])
+    swarm.show()
+    return swarm
+
+
+def test_last_flag_not_removed():
+    swarm = create_swarm()
+    swarm.queue.add_flag_at((50, 50), NormalFlag)
+    assert len(swarm.queue) == 1
+    swarm._tick(0)
+    assert len(swarm.queue) == 1


### PR DESCRIPTION
## Summary
- stop removing the last flag from the order queue
- add regression test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68485b304090832e9abfe5462588001d