### PR TITLE
Add classic interface controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,26 +25,25 @@ Execute the simulation using the provided helper script:
 ./run.sh
 ```
 
-Use the `1`, `2`, `3` and `4` keys to choose which red flag is active. The icons for the
-four flags are shown at the bottom of the window. The active flag is highlighted
-with a rectangle. Control groups allow commands to target subsets of your army.
-Groups are numbered from `1` to `9`; by default footmen are in group `1` and
-archers in group `2`. Flag 1 controls only group `1`, flag 2 controls only group
-`2`, flag 3 orders units to move quickly (speed ×1.5) and disables their attacks,
-and flag 4 tells ants to stay put while still allowing them to attack. Click
-anywhere to append a new command to the selected group's queue. Holding `Shift`
-while clicking places a fast-move flag regardless of the current selection. Each control group
-maintains its own list of commands executed in the order they were added. Press the
-`Delete` key to remove the most recently queued flag for the active group. Press
-`Backspace` to clear that group's queue. Clicking a flag along its path removes
-only that flag from the queue. A dashed line shows the planned path from
-each control group to the flags in its queue so you can see orders for all groups
-at a glance. The simulation
-updates about 10 times per second and displays a small flag instead of a green
-square.
-Each control group also shows a small banner at its center of mass with the
-group number, making it easier to identify footmen and archer groups during
-battle.
+Control groups allow commands to target subsets of your army. Groups are
+numbered from `1` to `9`; by default footmen are in group `1` and archers in
+group `2`. Use the numeric keys `1` and `2` to select the active group.
+
+Commands are issued using the mouse or hotkeys:
+
+- Left click or press `A` to place an attack flag, replacing the current queue.
+- Hold `Shift` while clicking or pressing `A` to append an attack flag instead.
+- Press `M` to place a fast-move flag that clears the queue.
+- Hold `Shift` with `M` to append a fast-move flag.
+
+Press the `Delete` key to remove the most recently queued flag for the active
+group and `Backspace` to clear that group's queue. Clicking a flag along its path
+removes only that flag. A dashed line shows the planned path from each control
+group to its queued flags so you can see orders for all groups at a glance. The
+simulation updates about 10 times per second and displays a small flag instead of
+a green square. Each control group also shows a small banner at its center of
+mass with the group number, making it easier to identify footmen and archer
+groups during battle.
 
 ## Gameplay
 

--- a/game_field.py
+++ b/game_field.py
@@ -99,18 +99,21 @@ class GameField(Stage):
     def _handle_event(self, event):
         if event.type == pygame.KEYDOWN:
             if event.key == pygame.K_1:
-                self.active_flag_idx = 0
                 self.active_group = self.GROUP_FOOTMEN
                 return True
             if event.key == pygame.K_2:
-                self.active_flag_idx = 1
                 self.active_group = self.GROUP_ARCHERS
                 return True
-            if event.key == pygame.K_3:
-                self.active_flag_idx = 2
-                return True
-            if event.key == pygame.K_4:
-                self.active_flag_idx = 3
+            if event.key in (pygame.K_a, pygame.K_m):
+                flag_cls = NormalFlag if event.key == pygame.K_a else FastFlag
+                pos = pygame.mouse.get_pos()
+                queue = self.flag_queues[self.active_group]
+                mods = getattr(event, "mod", pygame.key.get_mods())
+                if mods & pygame.KMOD_SHIFT:
+                    queue.add_flag_at(pos, flag_cls)
+                else:
+                    queue.clear()
+                    queue.add_flag_at(pos, flag_cls)
                 return True
             if event.key == pygame.K_DELETE:
                 if self.flag_queues[self.active_group]:
@@ -119,12 +122,13 @@ class GameField(Stage):
             if event.key == pygame.K_BACKSPACE:
                 self.flag_queues[self.active_group].clear()
                 return True
-        elif event.type == pygame.MOUSEBUTTONDOWN:
+        elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            queue = self.flag_queues[self.active_group]
             if pygame.key.get_mods() & pygame.KMOD_SHIFT:
-                flag_cls = FastFlag
+                queue.add_flag_at(event.pos, NormalFlag)
             else:
-                flag_cls = self.flag_templates[self.active_flag_idx]["cls"]
-            self.flag_queues[self.active_group].add_flag_at(event.pos, flag_cls)
+                queue.clear()
+                queue.add_flag_at(event.pos, NormalFlag)
             return True
         return False
 

--- a/tests/test_gamefield_flags.py
+++ b/tests/test_gamefield_flags.py
@@ -40,36 +40,61 @@ def test_click_adds_flag():
     assert isinstance(queue[0], NormalFlag)
 
 
-def test_shift_click_adds_fast_flag():
+def test_shift_click_appends_flag():
     field = create_field()
+    event = pygame.event.Event(pygame.MOUSEBUTTONDOWN, pos=(10, 10), button=1)
+    field.handleEvent(event)
     pygame.key.set_mods(pygame.KMOD_SHIFT)
     event = pygame.event.Event(pygame.MOUSEBUTTONDOWN, pos=(20, 20), button=1)
     field.handleEvent(event)
     pygame.key.set_mods(0)
     queue = field.flag_queues[field.active_group]
-    assert len(queue) == 1
-    assert isinstance(queue[0], FastFlag)
+    assert len(queue) == 2
+    assert isinstance(queue[0], NormalFlag)
+    assert isinstance(queue[1], NormalFlag)
 
 
-def test_three_clicks_add_three_flags():
+def test_three_clicks_replace_queue():
     field = create_field()
     positions = [(5, 5), (15, 15), (25, 25)]
     for pos in positions:
         event = pygame.event.Event(pygame.MOUSEBUTTONDOWN, pos=pos, button=1)
         field.handleEvent(event)
     queue = field.flag_queues[field.active_group]
-    assert len(queue) == 3
+    assert len(queue) == 1
+    assert queue[0].pos == positions[-1]
 
 
 def test_clicking_existing_flag_removes_it():
     field = create_field()
-    a, b, c = (5, 5), (15, 15), (25, 25)
-    for pos in (a, b, c):
-        event = pygame.event.Event(pygame.MOUSEBUTTONDOWN, pos=pos, button=1)
-        field.handleEvent(event)
-    # Click on the second flag again to remove it
-    event = pygame.event.Event(pygame.MOUSEBUTTONDOWN, pos=b, button=1)
+    pos = (10, 10)
+    event = pygame.event.Event(pygame.MOUSEBUTTONDOWN, pos=pos, button=1)
+    field.handleEvent(event)
+    event = pygame.event.Event(pygame.MOUSEBUTTONDOWN, pos=pos, button=1)
     field.handleEvent(event)
     queue = field.flag_queues[field.active_group]
-    positions = [flag.pos for flag in queue]
-    assert positions == [a, c]
+    assert len(queue) == 0
+
+
+def test_m_key_sets_fast_flag():
+    field = create_field()
+    pygame.mouse.set_pos((40, 40))
+    event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_m)
+    field.handleEvent(event)
+    queue = field.flag_queues[field.active_group]
+    assert len(queue) == 1
+    assert isinstance(queue[0], FastFlag)
+
+
+def test_shift_m_appends_fast_flag():
+    field = create_field()
+    pygame.mouse.set_pos((10, 10))
+    event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_m)
+    field.handleEvent(event)
+    pygame.mouse.set_pos((20, 20))
+    event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_m, mod=pygame.KMOD_SHIFT)
+    field.handleEvent(event)
+    queue = field.flag_queues[field.active_group]
+    assert len(queue) == 2
+    assert isinstance(queue[0], FastFlag)
+    assert isinstance(queue[1], FastFlag)


### PR DESCRIPTION
## Summary
- update command controls for a more classic RTS-style interface
- clarify usage in README
- adapt GameField to new hotkeys and queue semantics
- update and extend tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68485df8be4c832eb36b94ff0509e3e6