### PR TITLE
Add fast flag mechanics

### DIFF
--- a/game_field.py
+++ b/game_field.py
@@ -179,6 +179,8 @@ class GameField(Stage):
         self._handle_combat(self.ai_player.swarm_archers, self.swarm_archers, ARCHER_ATTACK_RANGE, ARCHER_KILL_PROBABILITY)
 
     def _handle_combat(self, attackers, defenders, attack_range, kill_prob):
+        if attackers.is_fast_moving():
+            return
         engaged_attackers = set()
         engaged_defenders = set()
         remove_indices = []

--- a/swarm.py
+++ b/swarm.py
@@ -4,6 +4,7 @@ import pygame
 
 from stage import Stage
 from order_queue import OrderQueue
+from flag import FastFlag
 
 DOT_SIZE = 4
 BACKGROUND_COLOR = (0, 0, 0)
@@ -166,6 +167,11 @@ class Swarm(Stage):
     def first_flag(self):
         return self.queue[0] if self.queue else None
 
+    def is_fast_moving(self):
+        """Return True if the active flag is a FastFlag."""
+        flag = self.first_flag()
+        return isinstance(flag, FastFlag)
+
     def spawn(self, count, x_range, y_range, occupied, width=None, height=None, min_distance=None):
         """Populate the swarm with ``count`` units randomly inside the area."""
         width = self.width if width is None else width
@@ -281,7 +287,8 @@ class Swarm(Stage):
         flag = self.first_flag()
         flags = [flag] if flag else []
         all_ants = self.ants
-        proposed = self._propose_moves(self.ants, flags, all_ants, dt)
+        speed = dt * 1.5 if isinstance(flag, FastFlag) else dt
+        proposed = self._propose_moves(self.ants, flags, all_ants, speed)
         self.ants = [list(p) for p in self._resolve_positions(self.ants, proposed)]
 
         center = self.compute_centroid()

--- a/tests/test_fast_flag.py
+++ b/tests/test_fast_flag.py
@@ -1,0 +1,73 @@
+import os
+import sys
+import random
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import pygame
+
+from swarm import Swarm
+from flag import FastFlag, NormalFlag
+from game_field import GameField, ATTACK_RANGE
+
+os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
+
+
+class CombatField(GameField):
+    NUM_FOOTMEN = 0
+    NUM_ARCHERS = 0
+    NUM_ANTS_BLUE = 0
+    NUM_ARCHERS_BLUE = 0
+
+
+def create_swarm():
+    swarm = Swarm((255, 0, 0), 1, (255, 100, 100), width=100, height=100)
+    swarm.ants.append([10.0, 10.0])
+    swarm.show()
+    return swarm
+
+
+def create_combat_field():
+    field = CombatField(width=100, height=100)
+    field.swarm_footmen.ants = [[50, 50]]
+    field.ai_player.swarm_footmen.ants = [[52, 50]]
+    field.show()
+    return field
+
+
+@pytest.fixture(autouse=True)
+def init_pygame():
+    pygame.init()
+    yield
+    pygame.quit()
+
+
+def test_fast_flag_speeds_units():
+    random.seed(0)
+    normal = create_swarm()
+    normal.queue.add_flag_at((90, 10), NormalFlag)
+    normal._tick(1.0)
+    dist_normal = normal.ants[0][0] - 10.0
+
+    random.seed(0)
+    fast = create_swarm()
+    fast.queue.add_flag_at((90, 10), FastFlag)
+    fast._tick(1.0)
+    dist_fast = fast.ants[0][0] - 10.0
+
+    assert dist_fast == pytest.approx(dist_normal * 1.5, rel=1e-6)
+
+
+def test_fast_flag_disables_attack():
+    field = create_combat_field()
+    field.swarm_footmen.queue.add_flag_at((60, 50), FastFlag)
+    initial = len(field.ai_player.swarm_footmen.ants)
+    field._handle_combat(field.swarm_footmen, field.ai_player.swarm_footmen, ATTACK_RANGE, 1.0)
+    assert len(field.ai_player.swarm_footmen.ants) == initial
+
+    field.swarm_footmen.queue.clear()
+    field.swarm_footmen.queue.add_flag_at((60, 50), NormalFlag)
+    field.ai_player.swarm_footmen.ants = [[52, 50]]
+    field._handle_combat(field.swarm_footmen, field.ai_player.swarm_footmen, ATTACK_RANGE, 1.0)
+    assert len(field.ai_player.swarm_footmen.ants) == 0


### PR DESCRIPTION
## Summary
- speed flags accelerate swarms by 50%
- swarms ignore combat when a speed flag is active
- cover fast flag behavior with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684870c3ff40832e9390c481d3b19acc