### PR TITLE
Add Stage.getPosition() with subclass support

### DIFF
--- a/flag.py
+++ b/flag.py
@@ -14,6 +14,10 @@ class Flag(Stage):
         self.color = color
         self.number = number
 
+    def getPosition(self):
+        """Return the current flag position."""
+        return self.pos
+
     def draw_symbol(self, screen, pole_top):
         """Draw the basic triangular flag."""
         flag_points = [

--- a/stage.py
+++ b/stage.py
@@ -74,3 +74,10 @@ class Stage:
     def _tick(self, dt):
         """Subclasses override to update internal state."""
         pass
+
+    # ------------------------------------------------------------------
+    # Positioning
+    # ------------------------------------------------------------------
+    def getPosition(self):
+        """Return the (x, y) position of this stage element if available."""
+        return None

--- a/swarm.py
+++ b/swarm.py
@@ -164,6 +164,10 @@ class Swarm(Stage):
     def compute_centroid(self):
         return compute_centroid(self.ants)
 
+    def getPosition(self):
+        """Return the centroid position of this swarm."""
+        return self.compute_centroid()
+
     def first_flag(self):
         return self.queue[0] if self.queue else None
 

--- a/tests/test_get_position.py
+++ b/tests/test_get_position.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from stage import Stage
+from flag import NormalFlag
+from swarm import Swarm
+
+
+def test_stage_default_position_none():
+    stage = Stage()
+    assert stage.getPosition() is None
+
+
+def test_flag_get_position():
+    flag = NormalFlag((10, 20))
+    assert flag.getPosition() == (10, 20)
+
+
+def test_swarm_get_position():
+    swarm = Swarm((255, 0, 0), group_id=1, flag_color=(255, 100, 100), width=100, height=100)
+    swarm.ants = [[10, 20], [20, 30], [30, 40]]
+    assert swarm.getPosition() == (20, 30)
+
+
+def test_swarm_get_position_empty():
+    swarm = Swarm((255, 0, 0), group_id=1, flag_color=(255, 100, 100), width=100, height=100)
+    assert swarm.getPosition() is None


### PR DESCRIPTION
## Summary
- add `Stage.getPosition` method
- implement position logic for `Flag` and `Swarm`
- test that position methods return expected values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68487632fb8c832e9b6a388f48130535