### PR TITLE
Implement centroid caching for swarm

### DIFF
--- a/game_field.py
+++ b/game_field.py
@@ -195,5 +195,7 @@ class GameField(Stage):
                     break
         for j in sorted(set(remove_indices), reverse=True):
             defenders.ants.pop(j)
+        if remove_indices:
+            defenders._invalidate_centroid_cache()
         attackers.engaged.update(engaged_attackers)
         defenders.engaged.update(engaged_defenders)


### PR DESCRIPTION
## Summary
- cache swarm centroid to avoid expensive recomputation
- invalidate cached centroid when units move or are removed in combat

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684877a9fd98832e86dcca70dc6b20c7