### PR TITLE
Implement collision shape support

### DIFF
--- a/collision_shape.py
+++ b/collision_shape.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+from typing import Tuple
+
+@dataclass
+class CollisionShape:
+    """Simple circular collision shape."""
+
+    center: Tuple[float, float]
+    radius: float

--- a/stage.py
+++ b/stage.py
@@ -81,3 +81,7 @@ class Stage:
     def getPosition(self):
         """Return the (x, y) position of this stage element if available."""
         return None
+
+    def getCollisionShape(self):
+        """Return the collision shape of this element if available."""
+        return None

--- a/tests/test_collision_shape.py
+++ b/tests/test_collision_shape.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from stage import Stage
+from swarm import Swarm
+from collision_shape import CollisionShape
+
+
+def test_stage_collision_shape_none():
+    stage = Stage()
+    assert stage.getCollisionShape() is None
+
+
+def test_swarm_collision_shape():
+    swarm = Swarm((255, 0, 0), group_id=1, flag_color=(255, 100, 100), width=100, height=100)
+    swarm.ants = [[0, 0], [0, 10]]
+    shape = swarm.getCollisionShape()
+    assert isinstance(shape, CollisionShape)
+    assert shape.center == (0, 5)
+    assert shape.radius == 5
+
+
+def test_swarm_collision_shape_empty():
+    swarm = Swarm((255, 0, 0), group_id=1, flag_color=(255, 100, 100), width=100, height=100)
+    assert swarm.getCollisionShape() is None


### PR DESCRIPTION
## Summary
- implement a simple `CollisionShape` dataclass
- extend `Stage` with `getCollisionShape`
- compute collision shape for `Swarm` and draw dotted outline
- add tests for collision shapes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684878c8a984832eb22153d0f20ebcef