### PR TITLE
Implement collision detection in stage and swarm

### DIFF
--- a/collision_shape.py
+++ b/collision_shape.py
@@ -7,3 +7,12 @@ class CollisionShape:
 
     center: Tuple[float, float]
     radius: float
+
+    def collidesWith(self, other: "CollisionShape") -> bool:
+        """Return ``True`` if this shape intersects ``other``."""
+        if other is None:
+            return False
+        dx = self.center[0] - other.center[0]
+        dy = self.center[1] - other.center[1]
+        distance_sq = dx * dx + dy * dy
+        return distance_sq <= (self.radius + other.radius) ** 2

--- a/swarm.py
+++ b/swarm.py
@@ -170,6 +170,7 @@ class Swarm(Stage):
         self.flag_color = flag_color
         self.active = False
         self.engaged = set()
+        self.colliding_swarms = []
 
         # Cached centroid value for performance
         self._centroid_cache = None
@@ -208,6 +209,11 @@ class Swarm(Stage):
                 radius = dist
         return CollisionShape(center, radius)
 
+    def onCollision(self, stage):
+        """Record collisions with other swarms."""
+        if isinstance(stage, Swarm) and stage is not self:
+            self.colliding_swarms.append(stage)
+
     def first_flag(self):
         return self.queue[0] if self.queue else None
 
@@ -243,6 +249,13 @@ class Swarm(Stage):
         shape = self.getCollisionShape()
         if shape is not None:
             draw_dotted_circle(screen, shape.center, shape.radius)
+        center = self.compute_centroid()
+        if center:
+            for other in self.colliding_swarms:
+                other_center = other.compute_centroid()
+                if other_center:
+                    pygame.draw.line(screen, (255, 0, 0), center, other_center, width=3)
+        self.colliding_swarms.clear()
 
     # ------------------------------------------------------------------
     # Movement helpers

--- a/tests/test_collision_detection.py
+++ b/tests/test_collision_detection.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import pygame
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from stage import Stage
+from swarm import Swarm
+
+os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
+
+@pytest.fixture(autouse=True)
+def init_pygame():
+    pygame.init()
+    yield
+    pygame.quit()
+
+
+def create_swarm(pos, group_id):
+    swarm = Swarm((255, 0, 0), group_id, (255, 100, 100), width=100, height=100)
+    swarm.ants = [list(pos)]
+    swarm.show()
+    return swarm
+
+
+def test_swarms_detect_collision():
+    root = Stage()
+    s1 = create_swarm((10, 10), 1)
+    s2 = create_swarm((10, 10), 2)
+    root.add_stage(s1)
+    root.add_stage(s2)
+    root.show()
+    root.tick(0)
+    assert s2 in s1.colliding_swarms
+    assert s1 in s2.colliding_swarms
+
+
+def test_collision_cleared_after_draw():
+    root = Stage()
+    s1 = create_swarm((10, 10), 1)
+    s2 = create_swarm((10, 10), 2)
+    root.add_stage(s1)
+    root.add_stage(s2)
+    root.show()
+    root.tick(0)
+    screen = pygame.Surface((100, 100))
+    root.draw(screen)
+    assert s1.colliding_swarms == []
+    assert s2.colliding_swarms == []


### PR DESCRIPTION
## Summary
- add `CollisionShape.collidesWith` for circle collision math
- extend `Stage.tick` with global collision resolution
- provide empty `Stage.onCollision` method
- track collisions in `Swarm` and draw red indicators
- test swarm collision detection behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68487b0e7638832e8b69a8eac1bfbb0f