### PR TITLE
Increase collision radius to attack range

### DIFF
--- a/ai_player.py
+++ b/ai_player.py
@@ -1,5 +1,5 @@
 from stage import Stage
-from swarm import Swarm
+from swarm import Swarm, ATTACK_RANGE, ARCHER_ATTACK_RANGE
 from flag import NormalFlag, ArcherFlag
 import random
 
@@ -14,7 +14,14 @@ class AIPlayer(Stage):
         super().__init__()
         self.width = width
         self.height = height
-        self.swarm_footmen = Swarm((0, 255, 255), 5, (0, 255, 255), width=width, height=height)
+        self.swarm_footmen = Swarm(
+            (0, 255, 255),
+            5,
+            (0, 255, 255),
+            width=width,
+            height=height,
+            attack_range=ATTACK_RANGE,
+        )
         self.swarm_archers = Swarm(
             (0, 255, 255),
             6,
@@ -22,6 +29,7 @@ class AIPlayer(Stage):
             shape="semicircle",
             width=width,
             height=height,
+            attack_range=ARCHER_ATTACK_RANGE,
         )
         self.add_stage(self.swarm_footmen)
         self.add_stage(self.swarm_archers)

--- a/game_field.py
+++ b/game_field.py
@@ -52,7 +52,14 @@ class GameField(Stage):
         self.active_flag_idx = 0
 
         # Player-controlled swarms
-        self.swarm_footmen = Swarm((255, 0, 0), self.GROUP_FOOTMEN, self.FLAG_COLOR_RED, width=width, height=height)
+        self.swarm_footmen = Swarm(
+            (255, 0, 0),
+            self.GROUP_FOOTMEN,
+            self.FLAG_COLOR_RED,
+            width=width,
+            height=height,
+            attack_range=ATTACK_RANGE,
+        )
         self.swarm_archers = Swarm(
             (255, 0, 0),
             self.GROUP_ARCHERS,
@@ -60,6 +67,7 @@ class GameField(Stage):
             shape="semicircle",
             width=width,
             height=height,
+            attack_range=ARCHER_ATTACK_RANGE,
         )
 
         # Spawn units and create AI player
@@ -169,22 +177,22 @@ class GameField(Stage):
     # Combat resolution
     # ------------------------------------------------------------------
     def _resolve_combat(self):
-        self._handle_combat(self.swarm_footmen, self.ai_player.swarm_footmen, ATTACK_RANGE, KILL_PROBABILITY)
-        self._handle_combat(self.swarm_footmen, self.ai_player.swarm_archers, ATTACK_RANGE, KILL_PROBABILITY)
-        self._handle_combat(self.swarm_archers, self.ai_player.swarm_footmen, ARCHER_ATTACK_RANGE, ARCHER_KILL_PROBABILITY)
-        self._handle_combat(self.swarm_archers, self.ai_player.swarm_archers, ARCHER_ATTACK_RANGE, ARCHER_KILL_PROBABILITY)
-        self._handle_combat(self.ai_player.swarm_footmen, self.swarm_footmen, ATTACK_RANGE, KILL_PROBABILITY)
-        self._handle_combat(self.ai_player.swarm_footmen, self.swarm_archers, ATTACK_RANGE, KILL_PROBABILITY)
-        self._handle_combat(self.ai_player.swarm_archers, self.swarm_footmen, ARCHER_ATTACK_RANGE, ARCHER_KILL_PROBABILITY)
-        self._handle_combat(self.ai_player.swarm_archers, self.swarm_archers, ARCHER_ATTACK_RANGE, ARCHER_KILL_PROBABILITY)
+        self._handle_combat(self.swarm_footmen, self.ai_player.swarm_footmen, KILL_PROBABILITY)
+        self._handle_combat(self.swarm_footmen, self.ai_player.swarm_archers, KILL_PROBABILITY)
+        self._handle_combat(self.swarm_archers, self.ai_player.swarm_footmen, ARCHER_KILL_PROBABILITY)
+        self._handle_combat(self.swarm_archers, self.ai_player.swarm_archers, ARCHER_KILL_PROBABILITY)
+        self._handle_combat(self.ai_player.swarm_footmen, self.swarm_footmen, KILL_PROBABILITY)
+        self._handle_combat(self.ai_player.swarm_footmen, self.swarm_archers, KILL_PROBABILITY)
+        self._handle_combat(self.ai_player.swarm_archers, self.swarm_footmen, ARCHER_KILL_PROBABILITY)
+        self._handle_combat(self.ai_player.swarm_archers, self.swarm_archers, ARCHER_KILL_PROBABILITY)
 
-    def _handle_combat(self, attackers, defenders, attack_range, kill_prob):
+    def _handle_combat(self, attackers, defenders, kill_prob):
         if attackers.is_fast_moving():
             return
         engaged_attackers = set()
         engaged_defenders = set()
         remove_indices = []
-        range_sq = attack_range * attack_range
+        range_sq = attackers.attack_range * attackers.attack_range
         for i, (ax, ay) in enumerate(attackers.ants):
             for j, (dx, dy) in enumerate(defenders.ants):
                 if (ax - dx) ** 2 + (ay - dy) ** 2 <= range_sq:

--- a/swarm.py
+++ b/swarm.py
@@ -160,6 +160,7 @@ class Swarm(Stage):
         width=640,
         height=480,
         min_distance=4,
+        attack_range=ATTACK_RANGE,
     ):
         super().__init__()
         self.ants = []
@@ -178,6 +179,7 @@ class Swarm(Stage):
         self.width = width
         self.height = height
         self.min_distance = min_distance
+        self.attack_range = attack_range
 
         self.queue = OrderQueue()
         self.add_stage(self.queue)
@@ -207,6 +209,11 @@ class Swarm(Stage):
             dist = math.hypot(x - cx, y - cy)
             if dist > radius:
                 radius = dist
+
+        # Expand the collision radius by the swarm's attack range so that
+        # swarms register a collision when they are close enough to fight.
+        radius += self.attack_range
+
         return CollisionShape(center, radius)
 
     def onCollision(self, stage):

--- a/tests/test_collision_shape.py
+++ b/tests/test_collision_shape.py
@@ -19,7 +19,9 @@ def test_swarm_collision_shape():
     shape = swarm.getCollisionShape()
     assert isinstance(shape, CollisionShape)
     assert shape.center == (0, 5)
-    assert shape.radius == 5
+    # The collision shape radius now includes the swarm's attack range
+    # which expands the radius beyond the ants' positions.
+    assert shape.radius == 17
 
 
 def test_swarm_collision_shape_empty():

--- a/tests/test_fast_flag.py
+++ b/tests/test_fast_flag.py
@@ -9,7 +9,7 @@ import pygame
 
 from swarm import Swarm
 from flag import FastFlag, NormalFlag
-from game_field import GameField, ATTACK_RANGE
+from game_field import GameField
 
 os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
 
@@ -63,11 +63,11 @@ def test_fast_flag_disables_attack():
     field = create_combat_field()
     field.swarm_footmen.queue.add_flag_at((60, 50), FastFlag)
     initial = len(field.ai_player.swarm_footmen.ants)
-    field._handle_combat(field.swarm_footmen, field.ai_player.swarm_footmen, ATTACK_RANGE, 1.0)
+    field._handle_combat(field.swarm_footmen, field.ai_player.swarm_footmen, 1.0)
     assert len(field.ai_player.swarm_footmen.ants) == initial
 
     field.swarm_footmen.queue.clear()
     field.swarm_footmen.queue.add_flag_at((60, 50), NormalFlag)
     field.ai_player.swarm_footmen.ants = [[52, 50]]
-    field._handle_combat(field.swarm_footmen, field.ai_player.swarm_footmen, ATTACK_RANGE, 1.0)
+    field._handle_combat(field.swarm_footmen, field.ai_player.swarm_footmen, 1.0)
     assert len(field.ai_player.swarm_footmen.ants) == 0


### PR DESCRIPTION
## Summary
- expand swarm collision radius by `self.attack_range`
- store attack range on each swarm via the constructor
- simplify combat resolution to use stored attack ranges
- update fast flag test for new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684917e103b0832eac5e395b475afb01