### PR TITLE
Parameterize kill probability in Swarm

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ groups during battle.
 ## Gameplay
 
 Footmen attack the closest enemy within `ATTACK_RANGE` pixels (default `12`).
-Their attacks kill the target with probability defined by `KILL_PROBABILITY`
-(default `0.02`). Archers behave differently: they can attack from
-`ARCHER_ATTACK_RANGE` pixels (60 by default) but with a reduced kill chance of
-`ARCHER_KILL_PROBABILITY` (one third of the footman value). Defeated ants are
-removed from the simulation.
+Their attacks kill the target with a probability defined by the swarm's
+`kill_probability` parameter (default `0.02`). Archers behave differently: they
+can attack from `ARCHER_ATTACK_RANGE` pixels (60 by default) but with a reduced
+kill chance set via their own `kill_probability` value (one third of the
+footman value). Defeated ants are removed from the simulation.

--- a/ai_player.py
+++ b/ai_player.py
@@ -1,5 +1,11 @@
 from stage import Stage
-from swarm import Swarm, ATTACK_RANGE, ARCHER_ATTACK_RANGE
+from swarm import (
+    Swarm,
+    ATTACK_RANGE,
+    ARCHER_ATTACK_RANGE,
+    KILL_PROBABILITY,
+    ARCHER_KILL_PROBABILITY,
+)
 from flag import NormalFlag, ArcherFlag
 import random
 
@@ -21,6 +27,7 @@ class AIPlayer(Stage):
             width=width,
             height=height,
             attack_range=ATTACK_RANGE,
+            kill_probability=KILL_PROBABILITY,
         )
         self.swarm_archers = Swarm(
             (0, 255, 255),
@@ -30,6 +37,7 @@ class AIPlayer(Stage):
             width=width,
             height=height,
             attack_range=ARCHER_ATTACK_RANGE,
+            kill_probability=ARCHER_KILL_PROBABILITY,
         )
         self.add_stage(self.swarm_footmen)
         self.add_stage(self.swarm_archers)

--- a/game_field.py
+++ b/game_field.py
@@ -59,6 +59,7 @@ class GameField(Stage):
             width=width,
             height=height,
             attack_range=ATTACK_RANGE,
+            kill_probability=KILL_PROBABILITY,
         )
         self.swarm_archers = Swarm(
             (255, 0, 0),
@@ -68,6 +69,7 @@ class GameField(Stage):
             width=width,
             height=height,
             attack_range=ARCHER_ATTACK_RANGE,
+            kill_probability=ARCHER_KILL_PROBABILITY,
         )
 
         # Spawn units and create AI player
@@ -177,14 +179,46 @@ class GameField(Stage):
     # Combat resolution
     # ------------------------------------------------------------------
     def _resolve_combat(self):
-        self._handle_combat(self.swarm_footmen, self.ai_player.swarm_footmen, KILL_PROBABILITY)
-        self._handle_combat(self.swarm_footmen, self.ai_player.swarm_archers, KILL_PROBABILITY)
-        self._handle_combat(self.swarm_archers, self.ai_player.swarm_footmen, ARCHER_KILL_PROBABILITY)
-        self._handle_combat(self.swarm_archers, self.ai_player.swarm_archers, ARCHER_KILL_PROBABILITY)
-        self._handle_combat(self.ai_player.swarm_footmen, self.swarm_footmen, KILL_PROBABILITY)
-        self._handle_combat(self.ai_player.swarm_footmen, self.swarm_archers, KILL_PROBABILITY)
-        self._handle_combat(self.ai_player.swarm_archers, self.swarm_footmen, ARCHER_KILL_PROBABILITY)
-        self._handle_combat(self.ai_player.swarm_archers, self.swarm_archers, ARCHER_KILL_PROBABILITY)
+        self._handle_combat(
+            self.swarm_footmen,
+            self.ai_player.swarm_footmen,
+            self.swarm_footmen.kill_probability,
+        )
+        self._handle_combat(
+            self.swarm_footmen,
+            self.ai_player.swarm_archers,
+            self.swarm_footmen.kill_probability,
+        )
+        self._handle_combat(
+            self.swarm_archers,
+            self.ai_player.swarm_footmen,
+            self.swarm_archers.kill_probability,
+        )
+        self._handle_combat(
+            self.swarm_archers,
+            self.ai_player.swarm_archers,
+            self.swarm_archers.kill_probability,
+        )
+        self._handle_combat(
+            self.ai_player.swarm_footmen,
+            self.swarm_footmen,
+            self.ai_player.swarm_footmen.kill_probability,
+        )
+        self._handle_combat(
+            self.ai_player.swarm_footmen,
+            self.swarm_archers,
+            self.ai_player.swarm_footmen.kill_probability,
+        )
+        self._handle_combat(
+            self.ai_player.swarm_archers,
+            self.swarm_footmen,
+            self.ai_player.swarm_archers.kill_probability,
+        )
+        self._handle_combat(
+            self.ai_player.swarm_archers,
+            self.swarm_archers,
+            self.ai_player.swarm_archers.kill_probability,
+        )
 
     def _handle_combat(self, attackers, defenders, kill_prob):
         if attackers.is_fast_moving():

--- a/swarm.py
+++ b/swarm.py
@@ -161,6 +161,7 @@ class Swarm(Stage):
         height=480,
         min_distance=4,
         attack_range=ATTACK_RANGE,
+        kill_probability=KILL_PROBABILITY,
     ):
         super().__init__()
         self.ants = []
@@ -180,6 +181,7 @@ class Swarm(Stage):
         self.height = height
         self.min_distance = min_distance
         self.attack_range = attack_range
+        self.kill_probability = kill_probability
 
         self.queue = OrderQueue()
         self.add_stage(self.queue)


### PR DESCRIPTION
## Summary
- allow passing `kill_probability` into `Swarm`
- pass kill probability when constructing swarms in `GameField` and `AIPlayer`
- use swarms' `kill_probability` when resolving combat
- update gameplay documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68491dd7a14c832eb5cb1948a5d1912c