### PR TITLE
Implement Player classes with ownership logic

### DIFF
--- a/ai_player.py
+++ b/ai_player.py
@@ -1,4 +1,4 @@
-from stage import Stage
+from player import Player
 from swarm import (
     Swarm,
     ATTACK_RANGE,
@@ -13,7 +13,7 @@ import random
 TICKS_PER_SECOND = 20.0
 
 
-class AIPlayer(Stage):
+class AIPlayer(Player):
     """Simple AI controller for the blue team."""
 
     def __init__(self, width, height, num_footmen, num_archers, occupied):
@@ -39,6 +39,8 @@ class AIPlayer(Stage):
             attack_range=ARCHER_ATTACK_RANGE,
             kill_probability=ARCHER_KILL_PROBABILITY,
         )
+        self.swarm_footmen.owner = self
+        self.swarm_archers.owner = self
         self.add_stage(self.swarm_footmen)
         self.add_stage(self.swarm_archers)
         self.swarm_footmen.show()

--- a/game_field.py
+++ b/game_field.py
@@ -10,6 +10,7 @@ from swarm import (
     ARCHER_KILL_PROBABILITY,
 )
 from ai_player import AIPlayer
+from human_player import HumanPlayer
 from flag import NormalFlag, FastFlag, StopFlag
 
 
@@ -51,51 +52,39 @@ class GameField(Stage):
         self.active_group = self.GROUP_FOOTMEN
         self.active_flag_idx = 0
 
-        # Player-controlled swarms
-        self.swarm_footmen = Swarm(
-            (255, 0, 0),
-            self.GROUP_FOOTMEN,
-            self.FLAG_COLOR_RED,
-            width=width,
-            height=height,
-            attack_range=ATTACK_RANGE,
-            kill_probability=KILL_PROBABILITY,
-        )
-        self.swarm_archers = Swarm(
-            (255, 0, 0),
-            self.GROUP_ARCHERS,
-            self.FLAG_COLOR_RED,
-            shape="semicircle",
-            width=width,
-            height=height,
-            attack_range=ARCHER_ATTACK_RANGE,
-            kill_probability=ARCHER_KILL_PROBABILITY,
-        )
-
-        # Spawn units and create AI player
+        # Create players and their swarms
         occupied = set()
-        self.swarm_footmen.spawn(
+        self.human_player = HumanPlayer(
+            width,
+            height,
             self.NUM_FOOTMEN,
-            (0, width * 0.25),
-            (height * 0.75, height),
-            occupied,
-        )
-        self.swarm_archers.spawn(
             self.NUM_ARCHERS,
-            (0, width * 0.25),
-            (0, height * 0.25),
+            occupied,
+            group_footmen=self.GROUP_FOOTMEN,
+            group_archers=self.GROUP_ARCHERS,
+            color=(255, 0, 0),
+            flag_color=self.FLAG_COLOR_RED,
+        )
+        self.ai_player = AIPlayer(
+            width,
+            height,
+            self.NUM_ANTS_BLUE,
+            self.NUM_ARCHERS_BLUE,
             occupied,
         )
 
-        self.ai_player = AIPlayer(width, height, self.NUM_ANTS_BLUE, self.NUM_ARCHERS_BLUE, occupied)
+        # Register enemies
+        self.human_player.enemies.append(self.ai_player)
+        self.ai_player.enemies.append(self.human_player)
+
+        self.swarm_footmen = self.human_player.swarm_footmen
+        self.swarm_archers = self.human_player.swarm_archers
 
         # Organise stage hierarchy
-        self.add_stage(self.swarm_footmen)
-        self.add_stage(self.swarm_archers)
+        self.add_stage(self.human_player)
         self.add_stage(self.ai_player)
 
-        self.swarm_footmen.show()
-        self.swarm_archers.show()
+        self.human_player.show()
         self.ai_player.show()
 
         self.flag_queues = {

--- a/human_player.py
+++ b/human_player.py
@@ -1,0 +1,54 @@
+from player import Player
+from swarm import Swarm, ATTACK_RANGE, ARCHER_ATTACK_RANGE, KILL_PROBABILITY, ARCHER_KILL_PROBABILITY
+
+
+class HumanPlayer(Player):
+    """Player controlled by the user."""
+
+    def __init__(self, width, height, num_footmen, num_archers, occupied,
+                 group_footmen=1, group_archers=2, color=(255, 0, 0),
+                 flag_color=(255, 100, 100)):
+        super().__init__()
+        self.width = width
+        self.height = height
+
+        self.swarm_footmen = Swarm(
+            color,
+            group_footmen,
+            flag_color,
+            width=width,
+            height=height,
+            attack_range=ATTACK_RANGE,
+            kill_probability=KILL_PROBABILITY,
+        )
+        self.swarm_archers = Swarm(
+            color,
+            group_archers,
+            flag_color,
+            shape="semicircle",
+            width=width,
+            height=height,
+            attack_range=ARCHER_ATTACK_RANGE,
+            kill_probability=ARCHER_KILL_PROBABILITY,
+        )
+
+        self.swarm_footmen.owner = self
+        self.swarm_archers.owner = self
+
+        self.add_stage(self.swarm_footmen)
+        self.add_stage(self.swarm_archers)
+        self.swarm_footmen.show()
+        self.swarm_archers.show()
+
+        self.swarm_footmen.spawn(
+            num_footmen,
+            (0, width * 0.25),
+            (height * 0.75, height),
+            occupied,
+        )
+        self.swarm_archers.spawn(
+            num_archers,
+            (0, width * 0.25),
+            (0, height * 0.25),
+            occupied,
+        )

--- a/player.py
+++ b/player.py
@@ -1,0 +1,21 @@
+from stage import Stage
+class Player(Stage):
+
+    """Base class for entities that control swarms."""
+
+    def __init__(self):
+        super().__init__()
+        self.enemies = []
+
+    # ------------------------------------------------------------------
+    # Ownership helpers
+    # ------------------------------------------------------------------
+    def isOwner(self, stage):
+        """Return True if ``stage`` belongs to this player."""
+        if stage is self:
+            return True
+        return getattr(stage, "owner", None) is self
+
+    def isEnemy(self, stage):
+        """Return True if ``stage`` is owned by any of this player's enemies."""
+        return any(enemy.isOwner(stage) for enemy in self.enemies)

--- a/swarm.py
+++ b/swarm.py
@@ -162,6 +162,7 @@ class Swarm(Stage):
         min_distance=4,
         attack_range=ATTACK_RANGE,
         kill_probability=KILL_PROBABILITY,
+        owner=None,
     ):
         super().__init__()
         self.ants = []
@@ -182,6 +183,7 @@ class Swarm(Stage):
         self.min_distance = min_distance
         self.attack_range = attack_range
         self.kill_probability = kill_probability
+        self.owner = owner
 
         self.queue = OrderQueue()
         self.add_stage(self.queue)
@@ -220,8 +222,12 @@ class Swarm(Stage):
 
     def onCollision(self, stage):
         """Record collisions with other swarms."""
-        if isinstance(stage, Swarm) and stage is not self:
-            self.colliding_swarms.append(stage)
+        if self.owner:
+            if self.owner.isEnemy(stage):
+                self.colliding_swarms.append(stage)
+        else:
+            if isinstance(stage, Swarm) and stage is not self:
+                self.colliding_swarms.append(stage)
 
     def first_flag(self):
         return self.queue[0] if self.queue else None


### PR DESCRIPTION
## Summary
- add `Player` base class with ownership helpers
- create `HumanPlayer` that manages human-controlled swarms
- update `AIPlayer` to derive from `Player` and register swarm owners
- connect players in `GameField` and set enemy lists
- give `Swarm` an owner reference and update collision handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684921b91558832ea866497411ff77e4