### PR TITLE
Implement particle effect for footmen hits

### DIFF
--- a/ai_player.py
+++ b/ai_player.py
@@ -24,6 +24,7 @@ class AIPlayer(Player):
             (0, 255, 255),
             5,
             (0, 255, 255),
+            show_particles=True,
             width=width,
             height=height,
             attack_range=ATTACK_RANGE,

--- a/human_player.py
+++ b/human_player.py
@@ -16,6 +16,7 @@ class HumanPlayer(Player):
             color,
             group_footmen,
             flag_color,
+            show_particles=True,
             width=width,
             height=height,
             attack_range=ATTACK_RANGE,

--- a/swarm.py
+++ b/swarm.py
@@ -6,6 +6,7 @@ from stage import Stage
 from order_queue import OrderQueue
 from flag import FastFlag
 from collision_shape import CollisionShape
+from particle_shot import ParticleShot
 
 DOT_SIZE = 4
 BACKGROUND_COLOR = (0, 0, 0)
@@ -15,6 +16,9 @@ ATTACK_RANGE = 12
 KILL_PROBABILITY = 0.02
 ARCHER_ATTACK_RANGE = 60
 ARCHER_KILL_PROBABILITY = KILL_PROBABILITY / 3
+
+# Distance from attacker to display particle effects
+PARTICLE_DISTANCE = 3
 
 
 def lighten(color, factor=0.5):
@@ -163,6 +167,7 @@ class Swarm(Stage):
         attack_range=ATTACK_RANGE,
         kill_probability=KILL_PROBABILITY,
         owner=None,
+        show_particles=False,
     ):
         super().__init__()
         self.ants = []
@@ -184,6 +189,12 @@ class Swarm(Stage):
         self.attack_range = attack_range
         self.kill_probability = kill_probability
         self.owner = owner
+
+        self.particle_shot = None
+        if show_particles:
+            self.particle_shot = ParticleShot()
+            self.add_stage(self.particle_shot)
+            self.particle_shot.show()
 
         self.queue = OrderQueue()
         self.add_stage(self.queue)
@@ -233,6 +244,14 @@ class Swarm(Stage):
                 if (ax - dx) ** 2 + (ay - dy) ** 2 <= range_sq:
                     engaged_self.add(i)
                     engaged_other.add(j)
+                    if self.particle_shot is not None:
+                        dist = math.hypot(dx - ax, dy - ay)
+                        if dist == 0:
+                            px, py = ax, ay
+                        else:
+                            px = ax + (dx - ax) / dist * PARTICLE_DISTANCE
+                            py = ay + (dy - ay) / dist * PARTICLE_DISTANCE
+                        self.particle_shot.addParticle((px, py))
                     if random.random() < self.kill_probability:
                         remove_indices.append(j)
                     break

--- a/tests/test_particle_effect.py
+++ b/tests/test_particle_effect.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import math
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+pygame = pytest.importorskip('pygame')
+
+from swarm import Swarm, PARTICLE_DISTANCE
+
+os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
+
+@pytest.fixture(autouse=True)
+def init_pygame():
+    pygame.init()
+    yield
+    pygame.quit()
+
+
+def test_particle_added_on_attack():
+    attacker = Swarm((255, 0, 0), 1, (255, 100, 100), width=100, height=100, show_particles=True)
+    defender = Swarm((0, 0, 255), 2, (255, 100, 100), width=100, height=100)
+    attacker.ants = [[10, 10]]
+    defender.ants = [[11, 10]]
+    attacker.kill_probability = 0.0
+    attacker.onCollision(defender)
+    assert len(attacker.particle_shot._particles) == 1
+    px, py = attacker.particle_shot._particles[0]['pos']
+    expected_x = 10 + PARTICLE_DISTANCE
+    expected_y = 10
+    assert px == pytest.approx(expected_x)
+    assert py == pytest.approx(expected_y)


### PR DESCRIPTION
## Summary
- support optional particle effects in `Swarm`
- spawn the effect from the attacker on each hit
- enable particles for footman swarms
- add regression test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a92cf7994832eb2cf5ad37f1ea40b