### PR TITLE
Add ParticleArrow stage for archers

### DIFF
--- a/ai_player.py
+++ b/ai_player.py
@@ -35,6 +35,7 @@ class AIPlayer(Player):
             6,
             (0, 255, 255),
             shape="semicircle",
+            arrow_particles=True,
             width=width,
             height=height,
             attack_range=ARCHER_ATTACK_RANGE,

--- a/human_player.py
+++ b/human_player.py
@@ -27,6 +27,7 @@ class HumanPlayer(Player):
             group_archers,
             flag_color,
             shape="semicircle",
+            arrow_particles=True,
             width=width,
             height=height,
             attack_range=ARCHER_ATTACK_RANGE,

--- a/particle_arrow.py
+++ b/particle_arrow.py
@@ -1,0 +1,59 @@
+import math
+import pygame
+
+from stage import Stage
+
+
+class ParticleArrow(Stage):
+    """Moving line particle traveling from a start to end position."""
+
+    def __init__(self, length=5, start_speed=10, end_speed=5, color=(255, 255, 150)):
+        super().__init__()
+        self.length = length
+        self.start_speed = start_speed
+        self.end_speed = end_speed
+        self.color = color
+        self._particles = []
+
+    def addParticle(self, startingPos, endingPos):
+        """Add a new arrow particle moving from ``startingPos`` to ``endingPos``."""
+        dx = endingPos[0] - startingPos[0]
+        dy = endingPos[1] - startingPos[1]
+        distance = math.hypot(dx, dy)
+        if distance == 0:
+            return
+        direction = (dx / distance, dy / distance)
+        self._particles.append(
+            {
+                "start": startingPos,
+                "end": endingPos,
+                "dir": direction,
+                "distance": distance,
+                "traveled": 0.0,
+                "pos": startingPos,
+            }
+        )
+
+    def _tick(self, dt):
+        to_remove = []
+        for p in self._particles:
+            frac = p["traveled"] / p["distance"] if p["distance"] else 1.0
+            speed = self.start_speed + (self.end_speed - self.start_speed) * frac
+            move = speed * dt
+            p["traveled"] += move
+            if p["traveled"] >= p["distance"]:
+                to_remove.append(p)
+                continue
+            nx = p["start"][0] + p["dir"][0] * p["traveled"]
+            ny = p["start"][1] + p["dir"][1] * p["traveled"]
+            p["pos"] = (nx, ny)
+        for p in to_remove:
+            self._particles.remove(p)
+
+    def _draw(self, screen):
+        for p in self._particles:
+            x, y = p["pos"]
+            dx, dy = p["dir"]
+            start = (x, y)
+            end = (x + dx * self.length, y + dy * self.length)
+            pygame.draw.line(screen, self.color, start, end)

--- a/swarm.py
+++ b/swarm.py
@@ -168,6 +168,7 @@ class Swarm(Stage):
         kill_probability=KILL_PROBABILITY,
         owner=None,
         show_particles=False,
+        arrow_particles=False,
     ):
         super().__init__()
         self.ants = []
@@ -195,6 +196,13 @@ class Swarm(Stage):
             self.particle_shot = ParticleShot()
             self.add_stage(self.particle_shot)
             self.particle_shot.show()
+
+        self.particle_arrow = None
+        if arrow_particles:
+            from particle_arrow import ParticleArrow
+            self.particle_arrow = ParticleArrow()
+            self.add_stage(self.particle_arrow)
+            self.particle_arrow.show()
 
         self.queue = OrderQueue()
         self.add_stage(self.queue)
@@ -252,6 +260,16 @@ class Swarm(Stage):
                             px = ax + (dx - ax) / dist * PARTICLE_DISTANCE
                             py = ay + (dy - ay) / dist * PARTICLE_DISTANCE
                         self.particle_shot.addParticle((px, py))
+                    if self.particle_arrow is not None:
+                        dist = math.hypot(dx - ax, dy - ay)
+                        if dist == 0:
+                            start = (ax, ay)
+                        else:
+                            start = (
+                                ax + (dx - ax) / dist * PARTICLE_DISTANCE,
+                                ay + (dy - ay) / dist * PARTICLE_DISTANCE,
+                            )
+                        self.particle_arrow.addParticle(start, (dx, dy))
                     if random.random() < self.kill_probability:
                         remove_indices.append(j)
                     break

--- a/tests/test_particle_arrow.py
+++ b/tests/test_particle_arrow.py
@@ -1,0 +1,61 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+pygame = pytest.importorskip('pygame')
+
+from particle_arrow import ParticleArrow
+from swarm import Swarm, ARCHER_ATTACK_RANGE
+
+os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
+
+@pytest.fixture(autouse=True)
+def init_pygame():
+    pygame.init()
+    yield
+    pygame.quit()
+
+
+def test_particlearrow_moves_and_expires():
+    pa = ParticleArrow()
+    pa.addParticle((0, 0), (20, 0))
+    assert len(pa._particles) == 1
+    pa.tick(1)
+    # particle should have moved roughly start speed (10 units)
+    x, y = pa._particles[0]['pos']
+    assert x == pytest.approx(10)
+    assert y == pytest.approx(0)
+    # advance enough ticks to reach end and be removed
+    for _ in range(5):
+        pa.tick(1)
+    assert len(pa._particles) == 0
+
+
+def test_arrow_particle_added_on_attack():
+    attacker = Swarm(
+        (255, 0, 0),
+        1,
+        (255, 100, 100),
+        width=100,
+        height=100,
+        attack_range=ARCHER_ATTACK_RANGE,
+        arrow_particles=True,
+    )
+    defender = Swarm(
+        (0, 0, 255),
+        2,
+        (255, 100, 100),
+        width=100,
+        height=100,
+    )
+    attacker.ants = [[10, 10]]
+    defender.ants = [[20, 10]]
+    attacker.kill_probability = 0.0
+    attacker.onCollision(defender)
+    assert len(attacker.particle_arrow._particles) == 1
+    p = attacker.particle_arrow._particles[0]
+    assert p["start"] == pytest.approx((15, 10))
+    assert p["end"] == pytest.approx((20, 10))
+


### PR DESCRIPTION
## Summary
- integrate ParticleArrow as an optional effect inside `Swarm`
- spawn arrow particles when archers attack
- enable arrow particles for human and AI archers
- extend particle arrow tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a97db2140832e87eb28a5b33e0e0d