### PR TITLE
Generate particles only on hit

### DIFF
--- a/swarm.py
+++ b/swarm.py
@@ -252,25 +252,26 @@ class Swarm(Stage):
                 if (ax - dx) ** 2 + (ay - dy) ** 2 <= range_sq:
                     engaged_self.add(i)
                     engaged_other.add(j)
-                    if self.particle_shot is not None:
-                        dist = math.hypot(dx - ax, dy - ay)
-                        if dist == 0:
-                            px, py = ax, ay
-                        else:
-                            px = ax + (dx - ax) / dist * PARTICLE_DISTANCE
-                            py = ay + (dy - ay) / dist * PARTICLE_DISTANCE
-                        self.particle_shot.addParticle((px, py))
-                    if self.particle_arrow is not None:
-                        dist = math.hypot(dx - ax, dy - ay)
-                        if dist == 0:
-                            start = (ax, ay)
-                        else:
-                            start = (
-                                ax + (dx - ax) / dist * PARTICLE_DISTANCE,
-                                ay + (dy - ay) / dist * PARTICLE_DISTANCE,
-                            )
-                        self.particle_arrow.addParticle(start, (dx, dy))
-                    if random.random() < self.kill_probability:
+                    hit = random.random() < self.kill_probability
+                    if hit:
+                        if self.particle_shot is not None:
+                            dist = math.hypot(dx - ax, dy - ay)
+                            if dist == 0:
+                                px, py = ax, ay
+                            else:
+                                px = ax + (dx - ax) / dist * PARTICLE_DISTANCE
+                                py = ay + (dy - ay) / dist * PARTICLE_DISTANCE
+                            self.particle_shot.addParticle((px, py))
+                        if self.particle_arrow is not None:
+                            dist = math.hypot(dx - ax, dy - ay)
+                            if dist == 0:
+                                start = (ax, ay)
+                            else:
+                                start = (
+                                    ax + (dx - ax) / dist * PARTICLE_DISTANCE,
+                                    ay + (dy - ay) / dist * PARTICLE_DISTANCE,
+                                )
+                            self.particle_arrow.addParticle(start, (dx, dy))
                         remove_indices.append(j)
                     break
         for j in sorted(set(remove_indices), reverse=True):

--- a/tests/test_particle_arrow.py
+++ b/tests/test_particle_arrow.py
@@ -33,7 +33,35 @@ def test_particlearrow_moves_and_expires():
     assert len(pa._particles) == 0
 
 
-def test_arrow_particle_added_on_attack():
+def test_arrow_particle_added_on_kill():
+    attacker = Swarm(
+        (255, 0, 0),
+        1,
+        (255, 100, 100),
+        width=100,
+        height=100,
+        attack_range=ARCHER_ATTACK_RANGE,
+        arrow_particles=True,
+    )
+    defender = Swarm(
+        (0, 0, 255),
+        2,
+        (255, 100, 100),
+        width=100,
+        height=100,
+    )
+    attacker.ants = [[10, 10]]
+    defender.ants = [[20, 10]]
+    attacker.kill_probability = 1.0
+    attacker.onCollision(defender)
+    assert len(attacker.particle_arrow._particles) == 1
+    p = attacker.particle_arrow._particles[0]
+    assert p["start"] == pytest.approx((15, 10))
+    assert p["end"] == pytest.approx((20, 10))
+    assert len(defender.ants) == 0
+
+
+def test_arrow_particle_not_added_on_miss():
     attacker = Swarm(
         (255, 0, 0),
         1,
@@ -54,8 +82,6 @@ def test_arrow_particle_added_on_attack():
     defender.ants = [[20, 10]]
     attacker.kill_probability = 0.0
     attacker.onCollision(defender)
-    assert len(attacker.particle_arrow._particles) == 1
-    p = attacker.particle_arrow._particles[0]
-    assert p["start"] == pytest.approx((15, 10))
-    assert p["end"] == pytest.approx((20, 10))
+    assert len(attacker.particle_arrow._particles) == 0
+    assert len(defender.ants) == 1
 

--- a/tests/test_particle_effect.py
+++ b/tests/test_particle_effect.py
@@ -18,16 +18,42 @@ def init_pygame():
     pygame.quit()
 
 
-def test_particle_added_on_attack():
-    attacker = Swarm((255, 0, 0), 1, (255, 100, 100), width=100, height=100, show_particles=True)
+def test_particle_added_on_kill():
+    attacker = Swarm(
+        (255, 0, 0),
+        1,
+        (255, 100, 100),
+        width=100,
+        height=100,
+        show_particles=True,
+    )
+    defender = Swarm((0, 0, 255), 2, (255, 100, 100), width=100, height=100)
+    attacker.ants = [[10, 10]]
+    defender.ants = [[11, 10]]
+    attacker.kill_probability = 1.0
+    attacker.onCollision(defender)
+    assert len(attacker.particle_shot._particles) == 1
+    px, py = attacker.particle_shot._particles[0]["pos"]
+    expected_x = 10 + PARTICLE_DISTANCE
+    expected_y = 10
+    assert px == pytest.approx(expected_x)
+    assert py == pytest.approx(expected_y)
+    assert len(defender.ants) == 0
+
+
+def test_no_particle_when_attack_misses():
+    attacker = Swarm(
+        (255, 0, 0),
+        1,
+        (255, 100, 100),
+        width=100,
+        height=100,
+        show_particles=True,
+    )
     defender = Swarm((0, 0, 255), 2, (255, 100, 100), width=100, height=100)
     attacker.ants = [[10, 10]]
     defender.ants = [[11, 10]]
     attacker.kill_probability = 0.0
     attacker.onCollision(defender)
-    assert len(attacker.particle_shot._particles) == 1
-    px, py = attacker.particle_shot._particles[0]['pos']
-    expected_x = 10 + PARTICLE_DISTANCE
-    expected_y = 10
-    assert px == pytest.approx(expected_x)
-    assert py == pytest.approx(expected_y)
+    assert len(attacker.particle_shot._particles) == 0
+    assert len(defender.ants) == 1


### PR DESCRIPTION
## Summary
- trigger ParticleShot and ParticleArrow when an attack kills a unit
- cover this behaviour with new tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a9ab371c8832ea906a4a23aa0d66d