### PR TITLE
Add non-attacking SwarmCannon unit

### DIFF
--- a/ai_player.py
+++ b/ai_player.py
@@ -3,6 +3,7 @@ from swarm import (
     Swarm,
     SwarmFootmen,
     SwarmArchers,
+    SwarmCannon,
     ATTACK_RANGE,
     ARCHER_ATTACK_RANGE,
     KILL_PROBABILITY,
@@ -18,7 +19,15 @@ TICKS_PER_SECOND = 20.0
 class AIPlayer(Player):
     """Simple AI controller for the blue team."""
 
-    def __init__(self, width, height, num_footmen, num_archers, occupied):
+    def __init__(
+        self,
+        width,
+        height,
+        num_footmen,
+        num_archers,
+        occupied,
+        num_cannons=3,
+    ):
         super().__init__()
         self.width = width
         self.height = height
@@ -40,12 +49,23 @@ class AIPlayer(Player):
             attack_range=ARCHER_ATTACK_RANGE,
             kill_probability=ARCHER_KILL_PROBABILITY,
         )
+        self.swarm_cannon = SwarmCannon(
+            (0, 255, 255),
+            7,
+            (0, 255, 255),
+            width=width,
+            height=height,
+            owner=self,
+        )
         self.swarm_footmen.owner = self
         self.swarm_archers.owner = self
+        # SwarmCannon owner already set
         self.add_stage(self.swarm_footmen)
         self.add_stage(self.swarm_archers)
+        self.add_stage(self.swarm_cannon)
         self.swarm_footmen.show()
         self.swarm_archers.show()
+        self.swarm_cannon.show()
 
         self.swarm_footmen.spawn(
             num_footmen,
@@ -57,6 +77,12 @@ class AIPlayer(Player):
             num_archers,
             (width * 0.75, width),
             (height * 0.75, height),
+            occupied,
+        )
+        self.swarm_cannon.spawn(
+            num_cannons,
+            (width * 0.95, width),
+            (height * 0.45, height * 0.55),
             occupied,
         )
 

--- a/game_field.py
+++ b/game_field.py
@@ -25,9 +25,12 @@ class GameField(Stage):
     NUM_ARCHERS = 50
     NUM_ANTS_BLUE = 200
     NUM_ARCHERS_BLUE = 50
+    NUM_CANNONS = 3
+    NUM_CANNONS_BLUE = 3
 
     GROUP_FOOTMEN = 1
     GROUP_ARCHERS = 2
+    GROUP_CANNON = 3
 
     BACKGROUND_COLOR = (0, 0, 0)
     FLAG_COLOR_RED = (255, 100, 100)
@@ -62,6 +65,8 @@ class GameField(Stage):
             occupied,
             group_footmen=self.GROUP_FOOTMEN,
             group_archers=self.GROUP_ARCHERS,
+            group_cannon=self.GROUP_CANNON,
+            num_cannons=self.NUM_CANNONS,
             color=(255, 0, 0),
             flag_color=self.FLAG_COLOR_RED,
         )
@@ -71,6 +76,7 @@ class GameField(Stage):
             self.NUM_ANTS_BLUE,
             self.NUM_ARCHERS_BLUE,
             occupied,
+            num_cannons=self.NUM_CANNONS_BLUE,
         )
 
         # Register enemies
@@ -79,6 +85,8 @@ class GameField(Stage):
 
         self.swarm_footmen = self.human_player.swarm_footmen
         self.swarm_archers = self.human_player.swarm_archers
+        self.swarm_cannon = self.human_player.swarm_cannon
+        self.ai_swarm_cannon = self.ai_player.swarm_cannon
 
         # Organise stage hierarchy
         self.add_stage(self.human_player)
@@ -90,6 +98,7 @@ class GameField(Stage):
         self.flag_queues = {
             self.GROUP_FOOTMEN: self.swarm_footmen.queue,
             self.GROUP_ARCHERS: self.swarm_archers.queue,
+            self.GROUP_CANNON: self.swarm_cannon.queue,
         }
 
     # ------------------------------------------------------------------
@@ -102,6 +111,9 @@ class GameField(Stage):
                 return True
             if event.key == pygame.K_2:
                 self.active_group = self.GROUP_ARCHERS
+                return True
+            if event.key == pygame.K_3:
+                self.active_group = self.GROUP_CANNON
                 return True
             if event.key in (pygame.K_a, pygame.K_m):
                 flag_cls = NormalFlag if event.key == pygame.K_a else FastFlag
@@ -139,6 +151,7 @@ class GameField(Stage):
         screen.fill(self.BACKGROUND_COLOR)
         self.swarm_footmen.active = self.active_group == self.GROUP_FOOTMEN
         self.swarm_archers.active = self.active_group == self.GROUP_ARCHERS
+        self.swarm_cannon.active = self.active_group == self.GROUP_CANNON
 
         # Flag icons
         for idx, template in enumerate(self.flag_templates):
@@ -160,6 +173,8 @@ class GameField(Stage):
     def _tick(self, dt):
         self.swarm_footmen.engaged = set()
         self.swarm_archers.engaged = set()
+        self.swarm_cannon.engaged = set()
         self.ai_player.swarm_archers.engaged = set()
         self.ai_player.swarm_footmen.engaged = set()
+        self.ai_swarm_cannon.engaged = set()
 

--- a/human_player.py
+++ b/human_player.py
@@ -3,6 +3,7 @@ from swarm import (
     Swarm,
     SwarmFootmen,
     SwarmArchers,
+    SwarmCannon,
     ATTACK_RANGE,
     ARCHER_ATTACK_RANGE,
     KILL_PROBABILITY,
@@ -13,9 +14,20 @@ from swarm import (
 class HumanPlayer(Player):
     """Player controlled by the user."""
 
-    def __init__(self, width, height, num_footmen, num_archers, occupied,
-                 group_footmen=1, group_archers=2, color=(255, 0, 0),
-                 flag_color=(255, 100, 100)):
+    def __init__(
+        self,
+        width,
+        height,
+        num_footmen,
+        num_archers,
+        occupied,
+        group_footmen=1,
+        group_archers=2,
+        group_cannon=3,
+        num_cannons=3,
+        color=(255, 0, 0),
+        flag_color=(255, 100, 100),
+    ):
         super().__init__()
         self.width = width
         self.height = height
@@ -38,14 +50,25 @@ class HumanPlayer(Player):
             attack_range=ARCHER_ATTACK_RANGE,
             kill_probability=ARCHER_KILL_PROBABILITY,
         )
+        self.swarm_cannon = SwarmCannon(
+            color,
+            group_cannon,
+            flag_color,
+            width=width,
+            height=height,
+            owner=self,
+        )
 
         self.swarm_footmen.owner = self
         self.swarm_archers.owner = self
+        # SwarmCannon owner already set in constructor
 
         self.add_stage(self.swarm_footmen)
         self.add_stage(self.swarm_archers)
+        self.add_stage(self.swarm_cannon)
         self.swarm_footmen.show()
         self.swarm_archers.show()
+        self.swarm_cannon.show()
 
         self.swarm_footmen.spawn(
             num_footmen,
@@ -57,5 +80,11 @@ class HumanPlayer(Player):
             num_archers,
             (0, width * 0.25),
             (0, height * 0.25),
+            occupied,
+        )
+        self.swarm_cannon.spawn(
+            num_cannons,
+            (0, width * 0.05),
+            (height * 0.45, height * 0.55),
             occupied,
         )


### PR DESCRIPTION
## Summary
- support new triangle shape and SwarmCannon class
- integrate cannons into human and AI players
- allow selecting group 3 in GameField
- spawn three cannons for both teams

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a9fd19a28832ea2295b05de3cadb3