### PR TITLE
Add cannon explosion animation

### DIFF
--- a/cannon_bullet.py
+++ b/cannon_bullet.py
@@ -2,6 +2,7 @@ import math
 import pygame
 
 from stage import Stage
+from explosion import Explosion
 
 
 class CannonBullet(Stage):
@@ -36,6 +37,9 @@ class CannonBullet(Stage):
             self.pos = self.end
             parent = getattr(self, "_parent", None)
             if parent is not None:
+                explosion = Explosion(self.pos)
+                parent.add_stage(explosion)
+                explosion.show()
                 parent.remove_stage(self)
             return
         self.pos = (

--- a/explosion.py
+++ b/explosion.py
@@ -1,0 +1,41 @@
+import pygame
+from stage import Stage
+
+
+class Explosion(Stage):
+    """Expanding circle animation used for cannon impacts."""
+
+    def __init__(self, pos, max_radius=50, duration=15):
+        super().__init__()
+        self.pos = pos
+        self.max_radius = max_radius
+        self.duration = duration
+        self.age = 0
+        self.start_radius = 4
+
+    def current_radius(self):
+        """Return the current radius of the explosion."""
+        frac = min(self.age / self.duration, 1)
+        progress = 1 - (1 - frac) ** 2
+        return self.start_radius + (self.max_radius - self.start_radius) * progress
+
+    def _tick(self, dt):
+        self.age += dt
+        if self.age >= self.duration:
+            parent = getattr(self, "_parent", None)
+            if parent is not None:
+                parent.remove_stage(self)
+            return
+
+    def _draw(self, screen):
+        if self.age > self.duration:
+            return
+        frac = min(self.age / self.duration, 1)
+        # Ease-out quadratic: fast start, slow end
+        progress = 1 - (1 - frac) ** 2
+        radius = self.start_radius + (self.max_radius - self.start_radius) * progress
+        alpha = int(255 * (1 - frac))
+        color = (255, 165, 0, alpha)
+        surface = pygame.Surface((self.max_radius * 2, self.max_radius * 2), pygame.SRCALPHA)
+        pygame.draw.circle(surface, color, (self.max_radius, self.max_radius), int(radius))
+        screen.blit(surface, (self.pos[0] - self.max_radius, self.pos[1] - self.max_radius))

--- a/swarm.py
+++ b/swarm.py
@@ -588,7 +588,7 @@ class SwarmCannon(Swarm):
     def _maybe_fire_bullet(self):
         """Fire a projectile toward the center occasionally."""
         for x, y in self.ants:
-            if random.random() < 0.01:
+            if random.random() < 0.002:
                 target = (self.width / 2, self.height / 2)
                 bullet = CannonBullet(self.owner, (x, y), target)
                 self.add_stage(bullet)

--- a/tests/test_explosion.py
+++ b/tests/test_explosion.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+pygame = pytest.importorskip('pygame')
+
+from explosion import Explosion
+from stage import Stage
+
+os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
+
+@pytest.fixture(autouse=True)
+def init_pygame():
+    pygame.init()
+    yield
+    pygame.quit()
+
+
+def test_explosion_expires():
+    exp = Explosion((0, 0), max_radius=20, duration=5)
+    root = Stage()
+    root.add_stage(exp)
+    root.show()
+    for _ in range(6):
+        root.tick(1)
+    assert exp not in root._children
+
+
+def test_explosion_radius_growth():
+    exp = Explosion((0, 0), max_radius=20, duration=5)
+    exp.show()
+    exp.tick(1)
+    r1 = exp.current_radius()
+    exp.tick(1)
+    r2 = exp.current_radius()
+    assert r2 > r1
+


### PR DESCRIPTION
## Summary
- lower `SwarmCannon` firing chance to 0.2%
- create reusable `Explosion` stage for a fading orange blast
- spawn an explosion when `CannonBullet` reaches its target
- add tests for the new explosion animation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aedfc0c70832e9fc6a6b16328925d