### PR TITLE
Speed up CannonBullet

### DIFF
--- a/cannon_bullet.py
+++ b/cannon_bullet.py
@@ -8,7 +8,8 @@ from explosion import Explosion
 class CannonBullet(Stage):
     """Projectile moving from start to end position with a pulsing size."""
 
-    BASE_SPEED = 4
+    # Increase base projectile speed slightly for a snappier feel
+    BASE_SPEED = 4.8
 
     def __init__(self, owner, pos1, pos2):
         super().__init__()

--- a/explosion.py
+++ b/explosion.py
@@ -1,9 +1,13 @@
+import random
 import pygame
 from stage import Stage
+from collision_shape import CollisionShape
 
 
 class Explosion(Stage):
     """Expanding circle animation used for cannon impacts."""
+
+    EXPLOSION_KILL_PROBABILITY = 0.3
 
     def __init__(self, pos, max_radius=50, duration=15, owner=None):
         super().__init__()
@@ -13,6 +17,9 @@ class Explosion(Stage):
         self.age = 0
         self.start_radius = 4
         self.owner = owner
+        self._collecting = False
+        self._collisions = []
+        self._processed = False
 
     def current_radius(self):
         """Return the current radius of the explosion."""
@@ -22,11 +29,38 @@ class Explosion(Stage):
 
     def _tick(self, dt):
         self.age += dt
-        if self.age >= self.duration:
+        if self.age > self.duration:
+            if not self._processed:
+                for swarm in self._collisions:
+                    if not swarm.ants:
+                        continue
+                    removed = []
+                    for idx in range(len(swarm.ants)):
+                        if random.random() < self.EXPLOSION_KILL_PROBABILITY:
+                            removed.append(idx)
+                    for idx in reversed(removed):
+                        swarm.ants.pop(idx)
+                    if removed:
+                        swarm._invalidate_centroid_cache()
+                self._processed = True
             parent = getattr(self, "_parent", None)
             if parent is not None:
                 parent.remove_stage(self)
             return
+
+        self._collecting = self.age >= self.duration - 1
+
+    def getCollisionShape(self):
+        if not self._collecting:
+            return None
+        return CollisionShape(self.pos, self.current_radius())
+
+    def onCollision(self, stage):
+        if not self._collecting:
+            return
+        if hasattr(stage, "ants") and self.owner and self.owner.isEnemy(stage):
+            if stage not in self._collisions:
+                self._collisions.append(stage)
 
     def _draw(self, screen):
         if self.age > self.duration:

--- a/swarm.py
+++ b/swarm.py
@@ -275,7 +275,7 @@ class Swarm(Stage):
 
     def _attack(self, defender):
         """Engage ``defender`` swarm, potentially removing its units."""
-        if self.is_fast_moving():
+        if self.is_fast_moving() or not hasattr(defender, "ants"):
             return
         engaged_self = set()
         engaged_other = set()

--- a/tests/test_explosion.py
+++ b/tests/test_explosion.py
@@ -6,8 +6,11 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 pygame = pytest.importorskip('pygame')
 
+import random
 from explosion import Explosion
 from stage import Stage
+from player import Player
+from swarm import Swarm
 
 os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
 
@@ -42,4 +45,30 @@ def test_explosion_has_owner():
     owner = object()
     exp = Explosion((0, 0), max_radius=10, duration=3, owner=owner)
     assert exp.owner is owner
+
+
+def test_explosion_damage_enemy(monkeypatch):
+    attacker = Player()
+    defender = Player()
+    attacker.enemies.append(defender)
+    defender.enemies.append(attacker)
+
+    swarm = Swarm((255, 0, 0), 1, (255, 100, 100), width=100, height=100)
+    swarm.owner = defender
+    swarm.ants = [[0, 0], [10, 0], [20, 0]]
+    swarm.show()
+
+    root = Stage()
+    exp = Explosion((0, 0), max_radius=10, duration=1, owner=attacker)
+    root.add_stage(swarm)
+    root.add_stage(exp)
+    root.show()
+
+    monkeypatch.setattr(random, "random", lambda: 0.0)
+
+    root.tick(1)
+    assert len(swarm.ants) == 3
+
+    root.tick(1)
+    assert len(swarm.ants) == 0
 


### PR DESCRIPTION
## Summary
- increase `CannonBullet.BASE_SPEED` by 20%
- add `Explosion.EXPLOSION_KILL_PROBABILITY` and apply damage to enemy swarms on the last frame
- prevent swarms attacking non-unit stages
- test explosion damage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684af1f4faec832e8cf5169710001d7d