### PR TITLE
Refine tree collision behavior

### DIFF
--- a/destructibles.py
+++ b/destructibles.py
@@ -9,7 +9,7 @@ import pygame
 class Tree(Stage):
     """Static destructible object with hit points."""
 
-    MAX_HP = 200
+    MAX_HP = 50
 
     def __init__(self, pos, size, owner=None):
         super().__init__()
@@ -28,18 +28,19 @@ class Tree(Stage):
 
     def onCollision(self, stage):
         if self.owner and self.owner.isEnemy(stage):
-            # Register a hit for each collision with an enemy stage
-            self.hp -= 1
-            amplitude = 3
-            for _ in range(3):
-                angle = random.uniform(0, 2 * math.pi)
-                dx = math.cos(angle) * amplitude
-                dy = math.sin(angle) * amplitude
-                self._shake_steps.extend([(dx, dy), (-dx, -dy)])
-            if self.hp <= 0:
-                parent = getattr(self, "_parent", None)
-                if parent is not None:
-                    parent.remove_stage(self)
+            hit_prob = getattr(stage, "kill_probability", 1.0)
+            if random.random() < hit_prob:
+                self.hp -= 1
+                amplitude = 1
+                for _ in range(3):
+                    angle = random.uniform(0, 2 * math.pi)
+                    dx = math.cos(angle) * amplitude
+                    dy = math.sin(angle) * amplitude
+                    self._shake_steps.extend([(dx, dy), (-dx, -dy)])
+                if self.hp <= 0:
+                    parent = getattr(self, "_parent", None)
+                    if parent is not None:
+                        parent.remove_stage(self)
 
     def _tick(self, dt):
         if self._shake_steps:

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import pytest
+import random
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from player import Player
+from swarm import Swarm
+from destructibles import Tree
+
+
+@pytest.fixture(autouse=True)
+def init_pygame():
+    pygame = pytest.importorskip('pygame')
+    pygame.init()
+    yield
+    pygame.quit()
+
+
+def create_tree_and_swarm():
+    owner = Player()
+    enemy = Player()
+    owner.enemies.append(enemy)
+    enemy.enemies.append(owner)
+
+    tree = Tree((10, 10), 5, owner=owner)
+    swarm = Swarm((255, 0, 0), 1, (255, 100, 100), width=100, height=100)
+    swarm.owner = enemy
+    swarm.ants = [[10, 10]]
+    swarm.kill_probability = 0.5
+    return tree, swarm
+
+
+def test_tree_hit_reduces_hp_and_shakes(monkeypatch):
+    tree, swarm = create_tree_and_swarm()
+    monkeypatch.setattr(random, "random", lambda: 0.4)
+    monkeypatch.setattr(random, "uniform", lambda a, b: 0.0)
+    hp_before = tree.hp
+    tree.onCollision(swarm)
+    assert tree.hp == hp_before - 1
+    assert tree._shake_steps[0] == pytest.approx((1.0, 0.0))
+
+
+def test_tree_miss_no_damage(monkeypatch):
+    tree, swarm = create_tree_and_swarm()
+    monkeypatch.setattr(random, "random", lambda: 0.6)
+    hp_before = tree.hp
+    tree.onCollision(swarm)
+    assert tree.hp == hp_before
+    assert not tree._shake_steps


### PR DESCRIPTION
## Summary
- tweak trees to have only 50 HP
- damage and shaking of trees now depend on attacker kill probability
- reduce tree shake amplitude
- add regression tests for tree collision logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c3521d120832ebad27a2705dbf691