### PR TITLE
Update tree durability and movement rules

### DIFF
--- a/destructibles.py
+++ b/destructibles.py
@@ -9,7 +9,7 @@ import pygame
 class Tree(Stage):
     """Static destructible object with hit points."""
 
-    MAX_HP = 50
+    MAX_HP = 20
 
     def __init__(self, pos, size, owner=None):
         super().__init__()
@@ -31,7 +31,7 @@ class Tree(Stage):
             hit_prob = getattr(stage, "kill_probability", 1.0)
             if random.random() < hit_prob:
                 self.hp -= 1
-                amplitude = 1
+                amplitude = 0.5
                 for _ in range(3):
                     angle = random.uniform(0, 2 * math.pi)
                     dx = math.cos(angle) * amplitude

--- a/swarm.py
+++ b/swarm.py
@@ -373,11 +373,28 @@ class Swarm(Stage):
     # ------------------------------------------------------------------
     # Movement helpers
     # ------------------------------------------------------------------
+    def _get_obstacle_shapes(self):
+        root = self
+        while getattr(root, "_parent", None) is not None:
+            root = root._parent
+        destructibles = getattr(root, "destructibles", None)
+        shapes = []
+        if destructibles:
+            for tree in getattr(destructibles, "trees", []):
+                shape = tree.getCollisionShape()
+                if shape is not None:
+                    shapes.append(shape)
+        return shapes
+
     def _is_valid_position(self, x, y, others):
         if not (0 <= x < self.width and 0 <= y < self.height):
             return False
         for ox, oy in others:
             if (x - ox) ** 2 + (y - oy) ** 2 < self.min_distance ** 2:
+                return False
+        ant_shape = CollisionShape((x, y), self.min_distance / 2)
+        for shape in self._get_obstacle_shapes():
+            if ant_shape.collidesWith(shape):
                 return False
         return True
 

--- a/tests/test_swarm_avoid_destructibles.py
+++ b/tests/test_swarm_avoid_destructibles.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from stage import Stage
+from destructibles import Destructibles, Tree
+from swarm import Swarm
+
+os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
+
+@pytest.fixture(autouse=True)
+def init_pygame():
+    pygame = pytest.importorskip('pygame')
+    pygame.init()
+    yield
+    pygame.quit()
+
+
+def test_unit_avoids_tree():
+    root = Stage()
+    destruct = Destructibles(100, 100, num_trees=0)
+    tree = Tree((20, 20), 5, owner=destruct)
+    destruct.trees.append(tree)
+    destruct.add_stage(tree)
+    root.destructibles = destruct
+    root.add_stage(destruct)
+
+    swarm = Swarm((255, 0, 0), 1, (255, 100, 100), width=100, height=100)
+    swarm.ants = [[10, 20]]
+    root.add_stage(swarm)
+
+    proposed = [(20, 20)]
+    result = swarm._resolve_positions(swarm.ants, proposed)
+    assert result[0] == (10, 20)

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -39,7 +39,7 @@ def test_tree_hit_reduces_hp_and_shakes(monkeypatch):
     hp_before = tree.hp
     tree.onCollision(swarm)
     assert tree.hp == hp_before - 1
-    assert tree._shake_steps[0] == pytest.approx((1.0, 0.0))
+    assert tree._shake_steps[0] == pytest.approx((0.5, 0.0))
 
 
 def test_tree_miss_no_damage(monkeypatch):


### PR DESCRIPTION
## Summary
- decrease tree MAX_HP to 20
- reduce tree shaking amplitude to 0.5
- ensure swarms avoid destructible obstacles
- test that swarms cannot move onto trees
- update existing tree shake test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c36e927e4832e82d17ae9629cb289