### PR TITLE
Implement lazy flow field and adjust weight

### DIFF
--- a/destructibles.py
+++ b/destructibles.py
@@ -62,6 +62,7 @@ class Destructibles(Player):
         self.width = width
         self.height = height
         self.trees = []
+        self._invalidators = []
         occupied = occupied if occupied is not None else set()
 
         for _ in range(num_trees):
@@ -76,4 +77,26 @@ class Destructibles(Player):
             self.add_stage(tree)
             tree.show()
             occupied.add((int(pos[0]), int(pos[1])))
+
+    def register_invalidator(self, func):
+        if callable(func):
+            self._invalidators.append(func)
+
+    def _notify_invalidator(self):
+        for cb in self._invalidators:
+            cb()
+
+    def add_stage(self, child):
+        super().add_stage(child)
+        if isinstance(child, Tree):
+            if child not in self.trees:
+                self.trees.append(child)
+            self._notify_invalidator()
+
+    def remove_stage(self, child):
+        super().remove_stage(child)
+        if isinstance(child, Tree):
+            if child in self.trees:
+                self.trees.remove(child)
+            self._notify_invalidator()
 

--- a/game_field.py
+++ b/game_field.py
@@ -94,6 +94,16 @@ class GameField(Stage):
         self.swarm_cannon = self.human_player.swarm_cannon
         self.ai_swarm_cannon = self.ai_player.swarm_cannon
 
+        for swarm in [
+            self.swarm_footmen,
+            self.swarm_archers,
+            self.swarm_cannon,
+            self.ai_player.swarm_footmen,
+            self.ai_player.swarm_archers,
+            self.ai_swarm_cannon,
+        ]:
+            self.destructibles.register_invalidator(swarm.invalidate_flow_field)
+
         # Organise stage hierarchy
         self.add_stage(self.human_player)
         self.add_stage(self.ai_player)

--- a/order_queue.py
+++ b/order_queue.py
@@ -4,9 +4,14 @@ from flag import Flag
 class OrderQueue(Stage):
     """Stage subclass managing an ordered list of Flag objects."""
 
-    def __init__(self):
+    def __init__(self, on_change=None):
         super().__init__()
         self._queue = []
+        self._on_change = on_change
+
+    def _notify(self):
+        if callable(self._on_change):
+            self._on_change()
 
     # ------------------------------------------------------------------
     # Basic list operations
@@ -17,6 +22,7 @@ class OrderQueue(Stage):
             raise TypeError("flag must be a Flag instance")
         self._queue.append(flag)
         self.add_stage(flag)
+        self._notify()
 
     def add_flag_at(self, pos, flag_cls=Flag):
         """Create a new flag instance at ``pos`` and append it."""
@@ -31,18 +37,21 @@ class OrderQueue(Stage):
             return None
         flag = self._queue.pop(index)
         self.remove_stage(flag)
+        self._notify()
         return flag
 
     def remove(self, flag):
         """Remove ``flag`` from the queue."""
         self._queue.remove(flag)
         self.remove_stage(flag)
+        self._notify()
 
     def clear(self):
         """Remove all flags from the queue."""
         for flag in list(self._queue):
             self.remove_stage(flag)
         self._queue.clear()
+        self._notify()
 
     # ------------------------------------------------------------------
     # Container protocol helpers


### PR DESCRIPTION
## Summary
- add change callback to `OrderQueue`
- invalidate and recompute flow field lazily in `Swarm`
- notify swarms when destructible trees change
- register destructible callbacks in `GameField`
- scale flow field vector influence by 3x

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c4a3c0f5c832e83e5fa9d8e078a46