### PR TITLE
Add center line of trees for cost field debugging

### DIFF
--- a/destructibles.py
+++ b/destructibles.py
@@ -57,7 +57,8 @@ class Tree(Stage):
 class Destructibles(Player):
     """Player controlling stationary destructible trees."""
 
-    def __init__(self, width, height, num_trees=20, occupied=None):
+    def __init__(self, width, height, num_trees=20, occupied=None,
+                 line_ratio=0.0, line_tree_size=15):
         super().__init__()
         self.width = width
         self.height = height
@@ -77,6 +78,21 @@ class Destructibles(Player):
             self.add_stage(tree)
             tree.show()
             occupied.add((int(pos[0]), int(pos[1])))
+
+        if line_ratio > 0.0:
+            step = line_tree_size * 2
+            desired = height * line_ratio
+            n_trees = max(1, int(math.ceil(desired / step)))
+            total = step * (n_trees - 1) + step
+            start_y = (height - total) / 2 + line_tree_size
+            cx = width / 2
+            for i in range(n_trees):
+                pos = (cx, start_y + step * i)
+                tree = Tree(pos, line_tree_size, owner=self)
+                self.trees.append(tree)
+                self.add_stage(tree)
+                tree.show()
+                occupied.add((int(pos[0]), int(pos[1])))
 
     def register_invalidator(self, func):
         if callable(func):

--- a/game_field.py
+++ b/game_field.py
@@ -84,7 +84,13 @@ class GameField(Stage):
             num_cannons=self.NUM_CANNONS_BLUE,
         )
 
-        self.destructibles = Destructibles(width, height, num_trees=20, occupied=occupied)
+        self.destructibles = Destructibles(
+            width,
+            height,
+            num_trees=20,
+            occupied=occupied,
+            line_ratio=0.5,
+        )
 
         # Register enemies
         self.human_player.enemies.append(self.ai_player)


### PR DESCRIPTION
## Summary
- allow Destructibles to optionally spawn a vertical line of touching trees
- enable this line of trees in GameField for cost-field visualisation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684d621d8574832e90a7555160766148