### PR TITLE
Remove tree line and expand obstacles for flow field

### DIFF
--- a/destructibles.py
+++ b/destructibles.py
@@ -57,8 +57,7 @@ class Tree(Stage):
 class Destructibles(Player):
     """Player controlling stationary destructible trees."""
 
-    def __init__(self, width, height, num_trees=20, occupied=None,
-                 line_ratio=0.0, line_tree_size=15):
+    def __init__(self, width, height, num_trees=20, occupied=None):
         super().__init__()
         self.width = width
         self.height = height
@@ -79,20 +78,7 @@ class Destructibles(Player):
             tree.show()
             occupied.add((int(pos[0]), int(pos[1])))
 
-        if line_ratio > 0.0:
-            step = line_tree_size * 2
-            desired = height * line_ratio
-            n_trees = max(1, int(math.ceil(desired / step)))
-            total = step * (n_trees - 1) + step
-            start_y = (height - total) / 2 + line_tree_size
-            cx = width / 2
-            for i in range(n_trees):
-                pos = (cx, start_y + step * i)
-                tree = Tree(pos, line_tree_size, owner=self)
-                self.trees.append(tree)
-                self.add_stage(tree)
-                tree.show()
-                occupied.add((int(pos[0]), int(pos[1])))
+
 
     def register_invalidator(self, func):
         if callable(func):

--- a/flow_field.py
+++ b/flow_field.py
@@ -1,9 +1,8 @@
-"""Grid based flow field pathfinding using numpy."""
+"""Grid based flow field pathfinding without external dependencies."""
 
 from collections import deque
 from typing import Iterable, Tuple
-
-import numpy as np
+import math
 
 from collision_shape import CollisionShape
 
@@ -29,12 +28,17 @@ class FlowField:
         self.grid_w = max(1, (width + cell_size - 1) // cell_size)
         self.grid_h = max(1, (height + cell_size - 1) // cell_size)
 
-        # Lazy gradient cache: (grid_h, grid_w, 2) filled with NaNs
-        self._vectors = np.full((self.grid_h, self.grid_w, 2), np.nan)
+        nan = float("nan")
+        self._vectors = [
+            [[nan, nan] for _ in range(self.grid_w)] for _ in range(self.grid_h)
+        ]
 
         # Cost field initialised to ``inf``
-        self.costs = np.full((self.grid_h, self.grid_w), np.inf)
-        self.INF = np.inf
+        inf = float("inf")
+        self.costs = [
+            [inf for _ in range(self.grid_w)] for _ in range(self.grid_h)
+        ]
+        self.INF = inf
 
         self.goal = None
         self.max_distance = 0.0
@@ -48,52 +52,68 @@ class FlowField:
     # ------------------------------------------------------------------
     # Field computation
     # ------------------------------------------------------------------
-    def compute(self, goal: Tuple[float, float], obstacles: Iterable[CollisionShape]):
-        """Compute the cost field towards ``goal`` avoiding ``obstacles``."""
+    def compute(
+        self,
+        goal: Tuple[float, float],
+        obstacles: Iterable[CollisionShape],
+        margin: float = 0.0,
+    ):
+        """Compute the cost field towards ``goal`` avoiding ``obstacles``.
+
+        ``margin`` expands the radius of each obstacle by the given amount
+        during computation.
+        """
         print("flow_field compute")
 
         self.goal = goal
 
-        blocked = np.zeros((self.grid_h, self.grid_w), dtype=bool)
+        blocked = [[False for _ in range(self.grid_w)] for _ in range(self.grid_h)]
         half = self.cell_size / 2
         for y in range(self.grid_h):
             for x in range(self.grid_w):
                 center = self._cell_center(x, y)
                 cell_shape = CollisionShape(center, half)
                 for shape in obstacles:
-                    if cell_shape.collidesWith(shape):
-                        blocked[y, x] = True
+                    inflated = CollisionShape(shape.center, shape.radius + margin)
+                    if cell_shape.collidesWith(inflated):
+                        blocked[y][x] = True
                         break
 
-        costs = np.full((self.grid_h, self.grid_w), np.inf)
+        costs = [[self.INF for _ in range(self.grid_w)] for _ in range(self.grid_h)]
         gx = min(self.grid_w - 1, max(0, int(goal[0] / self.cell_size)))
         gy = min(self.grid_h - 1, max(0, int(goal[1] / self.cell_size)))
-        if blocked[gy, gx]:
+        if blocked[gy][gx]:
             # goal blocked, nothing reachable
             self.costs = costs
-            self._vectors.fill(np.nan)
+            for y in range(self.grid_h):
+                for x in range(self.grid_w):
+                    self._vectors[y][x][0] = math.nan
+                    self._vectors[y][x][1] = math.nan
             self.max_distance = 0.0
             return
 
-        costs[gy, gx] = 0.0
+        costs[gy][gx] = 0.0
         q = deque([(gx, gy)])
 
         while q:
             cx, cy = q.popleft()
-            base = costs[cy, cx]
+            base = costs[cy][cx]
             for dx, dy in self.DIRECTIONS:
                 nx, ny = cx + dx, cy + dy
-                if 0 <= nx < self.grid_w and 0 <= ny < self.grid_h and not blocked[ny, nx]:
+                if 0 <= nx < self.grid_w and 0 <= ny < self.grid_h and not blocked[ny][nx]:
                     new_cost = base + (dx * dx + dy * dy) ** 0.5
-                    if new_cost < costs[ny, nx]:
-                        costs[ny, nx] = new_cost
+                    if new_cost < costs[ny][nx]:
+                        costs[ny][nx] = new_cost
                         q.append((nx, ny))
 
         self.costs = costs
-        self._vectors.fill(np.nan)
+        for y in range(self.grid_h):
+            for x in range(self.grid_w):
+                self._vectors[y][x][0] = math.nan
+                self._vectors[y][x][1] = math.nan
 
-        finite = costs[np.isfinite(costs)]
-        self.max_distance = float(finite.max()) if finite.size else 0.0
+        finite = [v for row in costs for v in row if math.isfinite(v)]
+        self.max_distance = max(finite) if finite else 0.0
 
     def get_vector(self, pos: Tuple[float, float]) -> Tuple[float, float]:
         """Return the flow vector for ``pos``."""
@@ -101,9 +121,9 @@ class FlowField:
             return 0.0, 0.0
         x = min(self.grid_w - 1, max(0, int(pos[0] / self.cell_size)))
         y = min(self.grid_h - 1, max(0, int(pos[1] / self.cell_size)))
-        if np.isnan(self._vectors[y, x, 0]):
-            self._vectors[y, x] = self._compute_vector(x, y)
-        return tuple(self._vectors[y, x])
+        if math.isnan(self._vectors[y][x][0]):
+            self._vectors[y][x] = self._compute_vector(x, y)
+        return tuple(self._vectors[y][x])
 
     def get_distance(self, pos: Tuple[float, float]) -> float:
         """Return the cost distance for ``pos`` or ``INF`` if unreachable."""
@@ -111,23 +131,23 @@ class FlowField:
             return self.INF
         x = min(self.grid_w - 1, max(0, int(pos[0] / self.cell_size)))
         y = min(self.grid_h - 1, max(0, int(pos[1] / self.cell_size)))
-        value = self.costs[y, x]
-        return float(value) if np.isfinite(value) else self.INF
+        value = self.costs[y][x]
+        return float(value) if math.isfinite(value) else self.INF
 
     # ------------------------------------------------------------------
     # Gradient helpers
     # ------------------------------------------------------------------
     def _compute_vector(self, x: int, y: int) -> Tuple[float, float]:
         """Compute normalized gradient at cell ``(x, y)``."""
-        if not np.isfinite(self.costs[y, x]):
+        if not math.isfinite(self.costs[y][x]):
             return (0.0, 0.0)
 
-        best_cost = self.costs[y, x]
+        best_cost = self.costs[y][x]
         best = (0, 0)
         for dx, dy in self.DIRECTIONS:
             nx, ny = x + dx, y + dy
             if 0 <= nx < self.grid_w and 0 <= ny < self.grid_h:
-                c = self.costs[ny, nx]
+                c = self.costs[ny][nx]
                 if c < best_cost:
                     best_cost = c
                     best = (dx, dy)

--- a/game_field.py
+++ b/game_field.py
@@ -89,7 +89,6 @@ class GameField(Stage):
             height,
             num_trees=20,
             occupied=occupied,
-            line_ratio=0.5,
         )
 
         # Register enemies

--- a/swarm.py
+++ b/swarm.py
@@ -354,7 +354,11 @@ class Swarm(Stage):
             or self._flow_field_dirty
         ):
             self._flow_field = FlowField(self.width, self.height)
-            self._flow_field.compute(flag.pos, self._get_obstacle_shapes())
+            self._flow_field.compute(
+                flag.pos,
+                self._get_obstacle_shapes(),
+                margin=5.0,
+            )
             self._flow_field_flag = flag
             self._flow_field_dirty = False
 

--- a/tests/test_flow_field_margin.py
+++ b/tests/test_flow_field_margin.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from flow_field import FlowField
+from collision_shape import CollisionShape
+
+
+def test_obstacle_margin_blocks_cells():
+    ff = FlowField(50, 50, cell_size=1)
+    obstacle = CollisionShape((20, 20), 5)
+    ff.compute((40, 40), [obstacle], margin=5.0)
+    assert ff.get_distance((25, 20)) == ff.INF
+    assert ff.get_distance((31, 20)) != ff.INF


### PR DESCRIPTION
## Summary
- remove support for line of trees
- expand obstacles by 5 px when computing flow field
- adjust call sites and add test
- drop numpy dependency by reimplementing flow field with Python lists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d742fd8dc832eb17b524237fe5777